### PR TITLE
fix: replace deprecated FlattenException

### DIFF
--- a/src/Controller/CustomExceptionController.php
+++ b/src/Controller/CustomExceptionController.php
@@ -5,21 +5,28 @@ namespace Sindla\Bundle\AuroraBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 
 class CustomExceptionController extends AbstractController
 {
-    public function handler(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null)
+    public function handler(Request $request, \Throwable $exception, DebugLoggerInterface $logger = null)
     {
-        return $this->render('@Aurora/error.html.twig',
+        $statusCode = $exception instanceof HttpExceptionInterface
+            ? $exception->getStatusCode()
+            : Response::HTTP_INTERNAL_SERVER_ERROR;
+
+        return $this->render(
+            '@Aurora/error.html.twig',
             [
-                'code'       => $exception->getStatusCode(),
-                'title'      => "[{$exception->getStatusCode()}] Sorry this page does not exist!",
+                'code'       => $statusCode,
+                'title'      => "[{$statusCode}] Sorry this page does not exist!",
                 'paragraphs' => [
-                    "Error code {$exception->getStatusCode()}",
-                    "The page does not exists."
+                    "Error code {$statusCode}",
+                    'The page does not exists.'
                 ]
-            ], new Response('', 404));
+            ],
+            new Response('', $statusCode)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- avoid using deprecated `FlattenException`
- fall back to generic exception handling and preserve HTTP status codes

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc262364508328a8552ef35f87bd57