### PR TITLE
Handle empty strings in character percentage helpers

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -553,6 +553,10 @@ class Strink
     public function lowerCharactersPercentage(): float
     {
         $total = strlen($this->string);
+        if (0 === $total) {
+            return 0.0;
+        }
+
         $lower = $this->countLowerCharacters();
         return BigDecimal::of($lower)->dividedBy($total, 0, RoundingMode::FLOOR)->multipliedBy(100)->toFloat();
     }
@@ -566,6 +570,10 @@ class Strink
     public function upperCharactersPercentage(): float
     {
         $total = strlen($this->string);
+        if (0 === $total) {
+            return 0.0;
+        }
+
         $upper = $this->countUpperCharacters();
         return BigDecimal::of($upper)->dividedBy($total, 0, RoundingMode::FLOOR)->multipliedBy(100)->toFloat();
     }

--- a/tests/Utils/AuroraHelper/AuroraHelperTest.php
+++ b/tests/Utils/AuroraHelper/AuroraHelperTest.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Strink;
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraHelper;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Sindla\Bundle\auroraBundle\Utils\AuroraHelper\AuroraHelper;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraHelper\AuroraHelper;
 
 /**
  * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraHelper/AuroraHelperTest.php --no-coverage
@@ -27,7 +26,7 @@ class AuroraHelperTest extends KernelTestCase
         $this->assertFalse(false);
     }
 
-    public function arrayToFlattenedDotPath(): void
+    public function testArrayToFlattenedDotPath(): void
     {
         $Helper = new AuroraHelper();
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -117,6 +117,13 @@ class StrinkTest extends KernelTestCase
 
     ##########################################################################################################################################################################################
 
+    public function testCharacterCasePercentageWithEmptyString(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals(0.0, $Strink->string('')->lowerCharactersPercentage());
+        $this->assertEquals(0.0, $Strink->string('')->upperCharactersPercentage());
+    }
+
     #[DataProvider('dataStrStartsWithAny')]
     public function testStrStartsWithAny(string $haystack, array $needles, bool $expected): void
     {


### PR DESCRIPTION
## Summary
- avoid division by zero in Strink's character percentage helpers
- test empty-string handling in Strink
- fix AuroraHelper test namespace and method name

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e763e408328831a4f4cf6e58057