### PR TITLE
Fix domain parsing in matchDomain

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -13,7 +13,7 @@ class AuroraMatch
 
         $parsedDomain = parse_url($domain);
         if (array_key_exists('scheme', $parsedDomain) && array_key_exists('host', $parsedDomain)) {
-            $domain = $parsedNeedle['host'];
+            $domain = $parsedDomain['host'];
         }
 
         preg_match('/(^|^[^:]+:\/\/|[^\.]+\.)' . preg_quote($domain) . '$/', $needle, $matches);

--- a/tests/Utils/AuroraMatch/AuroraMatchTest.php
+++ b/tests/Utils/AuroraMatch/AuroraMatchTest.php
@@ -48,6 +48,11 @@ class AuroraMatchTest extends KernelTestCase
                 'expected' => true,
             ],
             [
+                'needle'   => 'http://sindla.com',
+                'domain'   => 'https://sindla.com',
+                'expected' => true,
+            ],
+            [
                 'needle'   => 'https://sindla.com',
                 'domain'   => 'sindla.com',
                 'expected' => true,
@@ -103,6 +108,11 @@ class AuroraMatchTest extends KernelTestCase
                 'expected' => true,
             ],
             # false ------------------------------------------------------------------------
+            [
+                'needle'   => 'http://sindla.com',
+                'domain'   => 'https://notsindla.com',
+                'expected' => false,
+            ],
             [
                 'needle'   => 'http://sindla.com.myscamdomain.info',
                 'domain'   => 'sindla.com',


### PR DESCRIPTION
## Summary
- fix `matchDomain` to parse domain URL correctly
- add tests for domain comparisons with scheme

## Testing
- `./vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3cab1aac8328a5f392028964e795