### PR TITLE
Fix camel case conversion and word removal in Strink utility

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -168,8 +168,9 @@ class Strink
      */
     public function snakeCaseToCamelCase(bool $upperCaseFirsLetter = false): self
     {
-        $this->string = str_replace('_', '', ucwords('external_request_repository', '_'));
-        $this->string = (!$upperCaseFirsLetter ? lcfirst($this->string) : $this->string);
+        $this->string = str_replace('_', '', ucwords($this->string, '_'));
+        $this->string = !$upperCaseFirsLetter ? lcfirst($this->string) : $this->string;
+
         return $this;
     }
 
@@ -224,7 +225,9 @@ class Strink
             $this->string = preg_replace("/\b{$word}\b/i", '', $this->string);
         }
 
-        $this->string = trim($this->compressSpaces($this->string));
+        $this->compressSpaces();
+        $this->string = trim($this->string);
+
         return $this;
     }
 


### PR DESCRIPTION
## Summary
- fix `snakeCaseToCamelCase` using the actual string value instead of a hard-coded example
- ensure `removeWords` correctly trims extra spaces after removing words

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `~/.local/share/mise/installs/php/8.4.12/bin/php /usr/bin/phpunit -c phpunit.xml.dist tests/Utils/Strink/StrinkTest.php` *(fails: Class "Symfony\Bundle\FrameworkBundle\Test\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc50ca32a48328a28f22daf08cbb61