### PR TITLE
Fix IP version validation logic in crawler detection

### DIFF
--- a/src/Utils/AuroraIP/AuroraIP.php
+++ b/src/Utils/AuroraIP/AuroraIP.php
@@ -80,7 +80,7 @@ class AuroraIP
 
     public function isGoogle(string $ip): bool
     {
-        if ($this->isIPV4($ip) && $this->isIPV6($ip)) {
+        if (!$this->isIPV4($ip) && !$this->isIPV6($ip)) {
             return false;
         }
 
@@ -96,7 +96,7 @@ class AuroraIP
 
     public function isBing(string $ip): bool
     {
-        if ($this->isIPV4($ip) && $this->isIPV6($ip)) {
+        if (!$this->isIPV4($ip) && !$this->isIPV6($ip)) {
             return false;
         }
 
@@ -112,7 +112,7 @@ class AuroraIP
 
     public function isApple(string $ip): bool
     {
-        if ($this->isIPV4($ip) && $this->isIPV6($ip)) {
+        if (!$this->isIPV4($ip) && !$this->isIPV6($ip)) {
             return false;
         }
 
@@ -128,7 +128,7 @@ class AuroraIP
 
     public function isOpenAI(string $ip): bool
     {
-        if ($this->isIPV4($ip) && $this->isIPV6($ip)) {
+        if (!$this->isIPV4($ip) && !$this->isIPV6($ip)) {
             return false;
         }
 
@@ -144,7 +144,7 @@ class AuroraIP
 
     public function isUpTimeRobot(string $ip): bool
     {
-        if ($this->isIPV4($ip) && $this->isIPV6($ip)) {
+        if (!$this->isIPV4($ip) && !$this->isIPV6($ip)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- ensure crawler detection methods validate input IPs correctly

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc55c313748328af255baf2f935117