### PR TITLE
Use multibyte-safe case conversion

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -200,19 +200,21 @@ class Strink
 
     public function lower(): self
     {
-        $this->string = strtolower($this->string);
+        $this->string = mb_strtolower($this->string, mb_detect_encoding($this->string));
         return $this;
     }
 
     public function upper(): self
     {
-        $this->string = strtoupper($this->string);
+        $this->string = mb_strtoupper($this->string, mb_detect_encoding($this->string));
         return $this;
     }
 
     public function ucfirst(): self
     {
-        $this->string = ucfirst($this->string);
+        $encoding = mb_detect_encoding($this->string);
+        $this->string = mb_strtoupper(mb_substr($this->string, 0, 1, $encoding), $encoding)
+            . mb_substr($this->string, 1, null, $encoding);
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -115,6 +115,14 @@ class StrinkTest extends KernelTestCase
         $this->assertEquals('  Lorem  Isum  ', new Strink()->string("\r\rLorem\r\rIsum\r\r")->removeNewLines("\x20"));
     }
 
+    public function testUpperLowerAndUcfirst(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals('Ș', (string) $Strink->string('ș')->upper());
+        $this->assertEquals('ș', (string) $Strink->string('Ș')->lower());
+        $this->assertEquals('Șarpe', (string) $Strink->string('șarpe')->ucfirst());
+    }
+
     ##########################################################################################################################################################################################
 
     public function testCharacterCasePercentageWithEmptyString(): void


### PR DESCRIPTION
## Summary
- Handle multibyte characters when converting string case
- Cover Romanian diacritics with new unit test

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5761f4088328ac8a3dc95697a2d1