### PR TITLE
Fix character case percentage calculations

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -557,13 +557,19 @@ class Strink
 
     public function lowerCharactersPercentage(): float
     {
-        $total = strlen($this->string);
+        $encoding = mb_detect_encoding($this->string);
+        $total    = mb_strlen($this->string, $encoding);
+
         if (0 === $total) {
             return 0.0;
         }
 
         $lower = $this->countLowerCharacters();
-        return BigDecimal::of($lower)->dividedBy($total, 0, RoundingMode::FLOOR)->multipliedBy(100)->toFloat();
+
+        return BigDecimal::of($lower)
+            ->dividedBy($total, 2, RoundingMode::HALF_UP)
+            ->multipliedBy(100)
+            ->toFloat();
     }
 
     public function countUpperCharacters(): int
@@ -574,13 +580,19 @@ class Strink
 
     public function upperCharactersPercentage(): float
     {
-        $total = strlen($this->string);
+        $encoding = mb_detect_encoding($this->string);
+        $total    = mb_strlen($this->string, $encoding);
+
         if (0 === $total) {
             return 0.0;
         }
 
         $upper = $this->countUpperCharacters();
-        return BigDecimal::of($upper)->dividedBy($total, 0, RoundingMode::FLOOR)->multipliedBy(100)->toFloat();
+
+        return BigDecimal::of($upper)
+            ->dividedBy($total, 2, RoundingMode::HALF_UP)
+            ->multipliedBy(100)
+            ->toFloat();
     }
 
     /**

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -132,6 +132,20 @@ class StrinkTest extends KernelTestCase
         $this->assertEquals(0.0, $Strink->string('')->upperCharactersPercentage());
     }
 
+    public function testCharacterCasePercentage(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals(50.0, $Strink->string('Aa')->lowerCharactersPercentage());
+        $this->assertEquals(50.0, $Strink->string('Aa')->upperCharactersPercentage());
+    }
+
+    public function testCharacterCasePercentageWithUtf8(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals(50.0, $Strink->string('Șș')->lowerCharactersPercentage());
+        $this->assertEquals(50.0, $Strink->string('Șș')->upperCharactersPercentage());
+    }
+
     #[DataProvider('dataStrStartsWithAny')]
     public function testStrStartsWithAny(string $haystack, array $needles, bool $expected): void
     {


### PR DESCRIPTION
## Summary
- fix multibyte-aware character case percentage calculations
- add tests for ASCII and UTF-8 case percentage helpers

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bc598e1c54832896b6e153d5a78afa