### PR TITLE
Fix forwarded IP detection in AuroraClient

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -164,7 +164,11 @@ class AuroraClient
             return $_SERVER['HTTP_CF_CONNECTING_IP'];
         }
 
-        if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && !strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') && $this->ipIsValide($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        if (
+            isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+            && false === strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',')
+            && $this->ipIsValide($_SERVER['HTTP_X_FORWARDED_FOR'])
+        ) {
             return $_SERVER['HTTP_X_FORWARDED_FOR'];
         }
 


### PR DESCRIPTION
## Summary
- fix detection of X-Forwarded-For header when only one IP is provided

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: Symfony\Bundle\FrameworkBundle\Test\KernelTestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ac69c108328a6dea3a3d5ac519b