### PR TITLE
Fix logical operator in CSS minifier

### DIFF
--- a/src/Utils/Sanitizer/Sanitizer.php
+++ b/src/Utils/Sanitizer/Sanitizer.php
@@ -88,7 +88,7 @@ class Sanitizer
             foreach (preg_split("/((\r?\n)|(\r\n?))/", $css) as $line) {
                 $matches = $AuroraMatch->matchCssUrls($line);
 
-                if (isset($matches[0]) & !empty($matches[0])) {
+                if (isset($matches[0]) && !empty($matches[0])) {
                     foreach ($matches[0] as $urlToImport) {
                         $quote = '';
                         if (0 === strpos($urlToImport, "url('")) {


### PR DESCRIPTION
## Summary
- ensure CSS URL matching uses logical `&&`

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit tests/RequirementsTest.php` *(fails: Class "Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc84eeff448328a6395570272169fd