### PR TITLE
Fix private IP detection for invalid addresses

### DIFF
--- a/src/Utils/AuroraIP/AuroraIP.php
+++ b/src/Utils/AuroraIP/AuroraIP.php
@@ -23,7 +23,7 @@ class AuroraIP
 
     public function isPrivateIPV4(string $ip): bool
     {
-        return !$this->isPublicIPV4($ip);
+        return $this->isIPV4($ip) && !$this->isPublicIPV4($ip);
     }
 
     public function isIPV6(string $ip): bool
@@ -65,7 +65,7 @@ class AuroraIP
 
     private function isPrivateIPV6(string $ip): bool
     {
-        return !$this->isPublicIPV6($ip);
+        return $this->isIPV6($ip) && !$this->isPublicIPV6($ip);
     }
 
     public function isPrivate(string $ip): bool

--- a/tests/Utils/AuroraIP/AuroraIPTest.php
+++ b/tests/Utils/AuroraIP/AuroraIPTest.php
@@ -53,4 +53,22 @@ class AuroraIPTest extends KernelTestCase
             ['136.243.89.232', false]
         ];
     }
-}
+
+    #[DataProvider('dataIsPrivate')]
+    public function testIsPrivate(string $given, bool $expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            (new AuroraIP())->isPrivate($given),
+            'Given IP: ' . $given . ' != ' . ($expected ? 'true' : 'false')
+        );
+    }
+
+    public static function dataIsPrivate(): array
+    {
+        return [
+            ['127.0.0.1', true],
+            ['999.999.999.999', false]
+        ];
+    }
+  }


### PR DESCRIPTION
## Summary
- ensure private IP checks validate IPv4 and IPv6 formats
- add tests for invalid private IP addresses

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc89d4e82883288e3581b4244fc52d