### PR TITLE
Allow IPv6 validation in AuroraClient

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -204,10 +204,10 @@ class AuroraClient
         $ipIsValid = filter_var(
             $ip,
             FILTER_VALIDATE_IP,
-            FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
         );
 
-        return (($ipIsValid === false) ? false : true);
+        return $ipIsValid !== false;
     }
 
     /**

--- a/tests/Utils/AuroraClient/AuroraClientTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientTest.php
@@ -33,6 +33,21 @@ class AuroraClientTest extends KernelTestCase
         $this->assertFalse(false);
     }
 
+    public function testIpIsValideAcceptsIpv6(): void
+    {
+        $client = new AuroraClient($this->containerTest);
+
+        $this->assertTrue(
+            $client->ipIsValide('2001:4860:4860::8888'),
+            'Expected a public IPv6 address to be considered valid.'
+        );
+
+        $this->assertFalse(
+            $client->ipIsValide('::1'),
+            'Loopback IPv6 address should be considered invalid.'
+        );
+    }
+
     public function __SKIP__testIP2CountryCode()
     {
         $Client = new AuroraClient($this->containerTest);


### PR DESCRIPTION
## Summary
- allow IPv6 addresses in `AuroraClient::ipIsValide`
- cover `ipIsValide` with a test verifying IPv6 support

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8b0c6c108328aac77fcfacf9b73c