### PR TITLE
Fix array_any callback usage

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -605,12 +605,12 @@ class Strink
 
     public function strStartsWithAny(array $needles): bool
     {
-        return array_any($needles, fn($needle) => is_string($needle) && str_starts_with($this->string, $needle));
+        return array_any($needles, fn($needle, $_) => is_string($needle) && str_starts_with($this->string, $needle));
     }
 
     public function strEndsWithAny(array $needles): bool
     {
-        return array_any($needles, fn($needle) => is_string($needle) && str_ends_with($this->string, $needle));
+        return array_any($needles, fn($needle, $_) => is_string($needle) && str_ends_with($this->string, $needle));
     }
 
     public function __toString(): string


### PR DESCRIPTION
## Summary
- fix Strink::strStartsWithAny and strEndsWithAny callback signature

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27d24b488328b36d2844b22f2197