### PR TITLE
fix: make data provider static

### DIFF
--- a/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorTest.php
+++ b/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorTest.php
@@ -148,7 +148,7 @@ class AuroraCookiesExtractorTest extends KernelTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function cookieDataProvider(): array
+    public static function cookieDataProvider(): array
     {
         return [
             'single_cookie'    => [


### PR DESCRIPTION
## Summary
- ensure cookie data provider is static in tests for PHPUnit compatibility

## Testing
- `vendor/bin/phpunit` *(fails: Cannot bootstrap extension because class DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension does not exist; No code coverage driver available; No tests executed)*
- `vendor/bin/phpstan analyse` *(fails: bash: vendor/bin/phpstan: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2b76cb48832880f67cd85f2b0374