### PR TITLE
Fix named-parameter typo in Strink helpers

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -166,25 +166,25 @@ class Strink
      * Transform a snake_case string to camelCase or CamelCase
      * Translates a string with underscores into camel case (e.g. first_name -> firstName)
      */
-    public function snakeCaseToCamelCase(bool $upperCaseFirsLetter = false): self
+    public function snakeCaseToCamelCase(bool $upperCaseFirstLetter = false): self
     {
         $this->string = str_replace('_', '', ucwords($this->string, '_'));
-        $this->string = !$upperCaseFirsLetter ? lcfirst($this->string) : $this->string;
+        $this->string = !$upperCaseFirstLetter ? lcfirst($this->string) : $this->string;
 
         return $this;
     }
 
     /**
-     * Transform a snake_case string to "huma case" or "Human case" or "Human Case"
-     * Translates a string with underscores into camel case (e.g. first_name -> first name)
+     * Transform a snake_case string to "human case" or "Human case" or "Human Case".
+     * Translates a string with underscores into human readable words (e.g. first_name -> first name).
      */
-    public function snakeCaseToHumanCase(bool $upperCaseFirsLetter = false, bool $upperCaseAllLetter = false): self
+    public function snakeCaseToHumanCase(bool $upperCaseFirstLetter = false, bool $upperCaseAllLetters = false): self
     {
         $this->string = strtolower($this->string);
 
         $this->string = str_replace('_', ' ', $this->string);
-        $this->string = ($upperCaseFirsLetter ? ucfirst($this->string) : $this->string);
-        $this->string = ($upperCaseAllLetter ? ucwords($this->string) : $this->string);
+        $this->string = ($upperCaseFirstLetter ? ucfirst($this->string) : $this->string);
+        $this->string = ($upperCaseAllLetters ? ucwords($this->string) : $this->string);
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -63,7 +63,7 @@ class StrinkTest extends KernelTestCase
                      'ExternalRequestRepository' => ['external_request_repository', 'external_Request_repository', 'External_request_repository']
                  ] as $expected => $givens) {
             foreach ($givens as $given) {
-                $this->assertEquals($expected, $Strink->string($given)->snakeCaseToCamelCase(true));
+                $this->assertEquals($expected, $Strink->string($given)->snakeCaseToCamelCase(upperCaseFirstLetter: true));
             }
         }
 
@@ -72,7 +72,34 @@ class StrinkTest extends KernelTestCase
                      'externalRequestRepository' => ['external_request_repository', 'external_Request_repository', 'External_request_repository']
                  ] as $expected => $givens) {
             foreach ($givens as $given) {
-                $this->assertEquals($expected, $Strink->string($given)->snakeCaseToCamelCase(false));
+                $this->assertEquals($expected, $Strink->string($given)->snakeCaseToCamelCase(upperCaseFirstLetter: false));
+            }
+        }
+    }
+
+    public function testSnakeCaseToHumanCase(): void
+    {
+        $Strink = new Strink();
+
+        foreach ([
+                     'External request repository' => ['external_request_repository']
+                 ] as $expected => $givens) {
+            foreach ($givens as $given) {
+                $this->assertEquals(
+                    $expected,
+                    $Strink->string($given)->snakeCaseToHumanCase(upperCaseFirstLetter: true)
+                );
+            }
+        }
+
+        foreach ([
+                     'External Request Repository' => ['external_request_repository']
+                 ] as $expected => $givens) {
+            foreach ($givens as $given) {
+                $this->assertEquals(
+                    $expected,
+                    $Strink->string($given)->snakeCaseToHumanCase(upperCaseAllLetters: true)
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix `snakeCaseToCamelCase` and `snakeCaseToHumanCase` so their `upperCaseFirstLetter` parameters are correctly spelled
- cover named-parameter usage with new unit test

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `php /usr/bin/phpunit` *(fails: Class "Symfony\Bundle\FrameworkBundle\Test\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd34bedf8c832885f1f8f5742be52f