### PR TITLE
Fix invalid return types for time conversion helpers

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -303,7 +303,7 @@ class AuroraChronos
         return array_values($weeks);
     }
 
-    public function seconds2HMS(int $secs, ?bool $cutHourIfZero = false): string
+    public function seconds2HMS(int $secs, ?bool $cutHourIfZero = false): string|false
     {
         if ($secs < 0) {
             return false;
@@ -325,7 +325,7 @@ class AuroraChronos
         }
     }
 
-    public function seconds2HM(int $secs, bool $roundUp = false): string
+    public function seconds2HM(int $secs, bool $roundUp = false): string|false
     {
         if ($secs < 0) {
             return false;

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -272,4 +272,20 @@ class AuroraChronosTest extends KernelTestCase
             [1, [new \DateTimeImmutable('2024-03-01'), new \DateTimeImmutable('2024-02-28')]],
         ];
     }
+
+    public function testSeconds2HMS(): void
+    {
+        $Chronos = new AuroraChronos();
+
+        $this->assertSame('00:01:01', $Chronos->seconds2HMS(61));
+        $this->assertFalse($Chronos->seconds2HMS(-1));
+    }
+
+    public function testSeconds2HM(): void
+    {
+        $Chronos = new AuroraChronos();
+
+        $this->assertSame('00:01', $Chronos->seconds2HM(60));
+        $this->assertFalse($Chronos->seconds2HM(-1));
+    }
 }


### PR DESCRIPTION
## Summary
- Allow negative input handling in `seconds2HMS` and `seconds2HM` by permitting `false` return values
- Test time helpers for positive and negative seconds

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3869dbf4832897ab78bf401bbd9b