### PR TITLE
Fix obfuscateString margin usage

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -128,7 +128,7 @@ class Strink
     public function obfuscateString(mixed $string, int $margins = 2): string
     {
         return
-            substr($string, 0, min(2, strlen($string) - $margins))
+            substr($string, 0, min($margins, max(0, strlen($string) - $margins)))
             . str_repeat('*', max(0, strlen($string) - ($margins * 2)))
             . substr($string, strlen($string) - $margins, $margins);
     }

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -150,6 +150,13 @@ class StrinkTest extends KernelTestCase
         $this->assertEquals('Șarpe', (string) $Strink->string('șarpe')->ucfirst());
     }
 
+    public function testObfuscateString(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals('my**********ng', $Strink->obfuscateString('mysecretstring', 2));
+        $this->assertEquals('myse******ring', $Strink->obfuscateString('mysecretstring', 4));
+    }
+
     ##########################################################################################################################################################################################
 
     public function testCharacterCasePercentageWithEmptyString(): void


### PR DESCRIPTION
## Summary
- fix Strink::obfuscateString to honor given margins
- add unit test for string obfuscation margins

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d0440948328a123911c9f4f478c