### PR TITLE
Prefix array_any calls with global namespace

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -605,12 +605,12 @@ class Strink
 
     public function strStartsWithAny(array $needles): bool
     {
-        return array_any($needles, fn($needle, $_) => is_string($needle) && str_starts_with($this->string, $needle));
+        return \array_any($needles, fn($needle, $_) => is_string($needle) && str_starts_with($this->string, $needle));
     }
 
     public function strEndsWithAny(array $needles): bool
     {
-        return array_any($needles, fn($needle, $_) => is_string($needle) && str_ends_with($this->string, $needle));
+        return \array_any($needles, fn($needle, $_) => is_string($needle) && str_ends_with($this->string, $needle));
     }
 
     public function __toString(): string


### PR DESCRIPTION
## Summary
- ensure array_any is resolved from the global namespace in Strink helpers

## Testing
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan: No such file or directory)*
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8f4cf4f48328be4ada314b5ef55c