### PR TITLE
Respect relativeUrlOnly in matchCssUrls

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -34,9 +34,13 @@ class AuroraMatch
         return $matched;
     }
 
-    public function matchCssUrls(string $css, $relativeUrlOnly = true): array
+    public function matchCssUrls(string $css, bool $relativeUrlOnly = true): array
     {
-        preg_match_all("/url\((?!['\"]?(?:data|https|http):)['\"]?([^'\"\)]*)['\"]?\)/", $css, $matches);
+        $pattern = $relativeUrlOnly
+            ? '/url\((?![\'"]?(?:data|https|http):)[\'"]?([^\'"\)]*)[\'"]?\)/'
+            : '/url\([\'"]?([^\'"\)]*)[\'"]?\)/';
+
+        preg_match_all($pattern, $css, $matches);
         return $matches;
     }
 

--- a/tests/Utils/AuroraMatch/AuroraMatchTest.php
+++ b/tests/Utils/AuroraMatch/AuroraMatchTest.php
@@ -242,6 +242,12 @@ body {
 
         $this->assertEmpty($matches[0]);
         $this->assertEmpty($matches[1]);
+
+        $matches = $Match->matchCssUrls($css, false);
+        $this->assertSame(
+            'https://fonts.googleapis.com/css?family=Roboto:300,300i,400,500,700,900&display=swap',
+            $matches[1][0]
+        );
     }
 
     public function testPasswordStrength()


### PR DESCRIPTION
## Summary
- ensure `matchCssUrls` obeys the `relativeUrlOnly` flag, allowing optional absolute URL matches
- add unit test covering absolute URL matches when filtering is disabled

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2609ff08328955e5a65337cc883