### PR TITLE
Fix slugify camelCase conversion

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -482,7 +482,7 @@ class Strink
         $caseLower = count($match[0]);
 
         if ($caseLower > 0) {
-            $this->string = $this->camelCaseToSnakeCase($this->string);
+            $this->camelCaseToSnakeCase();
         }
 
         // replace non letter or digits by -


### PR DESCRIPTION
## Summary
- ensure slugify correctly converts camelCase strings by invoking camelCaseToSnakeCase without returning self

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit tests/Utils/Strink/StrinkTest.php` *(fails: Symfony\Bundle\FrameworkBundle\Test\KernelTestCase not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bda4f5261c8328a992412354bfd3c9