### PR TITLE
docs: clarify phpunit instructions in AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,5 +17,6 @@
 
 - Install dependencies with `composer install`.
 - Run static analysis using `vendor/bin/phpstan analyse`.
-- Execute unit tests with `vendor/bin/phpunit`.
+- Execute unit tests using `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist`.
+  For coverage reports, replace `--no-coverage` with `--coverage-clover coverage.xml`.
 


### PR DESCRIPTION
## Summary
- document phpunit options mirroring workflow defaults

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpstan analyse --memory-limit=-1` *(fails: class Symfony\Component\Dotenv\Dotenv not found)*
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: class Symfony\Bundle\FrameworkBundle\Test\KernelTestCase not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bda8f9153083289b97e9cedd8c81a4