### PR TITLE
Fix progress bar timestamp type

### DIFF
--- a/src/Command/Middleware/CommandMiddleware.php
+++ b/src/Command/Middleware/CommandMiddleware.php
@@ -32,7 +32,7 @@ class CommandMiddleware extends Command
     protected ManagerRegistry        $managerRegistry;
     protected EntityManagerInterface $em;
     private ?ProgressBar             $progressBar = null;
-    private \DatetimeInterface       $progressBarPreviousDisplay;
+    private \DateTimeInterface       $progressBarPreviousDisplay;
 
     public function __construct()
     {

--- a/tests/Command/CommandMiddlewareTest.php
+++ b/tests/Command/CommandMiddlewareTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Command\Middleware\CommandMiddleware;
+
+class CommandMiddlewareTest extends TestCase
+{
+    public function testProgressBarPreviousDisplayIsDateTime(): void
+    {
+        $command = new CommandMiddleware();
+        $reflection = new \ReflectionClass($command);
+        $property = $reflection->getProperty('progressBarPreviousDisplay');
+        $property->setAccessible(true);
+
+        $this->assertInstanceOf(\DateTimeInterface::class, $property->getValue($command));
+    }
+}


### PR DESCRIPTION
## Summary
- correct progress bar timestamp type to use DateTimeInterface
- add unit test verifying timestamp storage

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` (fails: Syntax error, unexpected ')' on line 39)
- `vendor/bin/phpunit --no-coverage tests/Command/CommandMiddlewareTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdbe11f1b88328aba9664fda3d1fc4