### PR TITLE
fix: escape words in removeWords

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -229,7 +229,8 @@ class Strink
     public function removeWords(array $wordsList): self
     {
         foreach ($wordsList as $word) {
-            $this->string = preg_replace("/\b{$word}\b/i", '', $this->string);
+            $escapedWord = preg_quote($word, '/');
+            $this->string = preg_replace('/\b' . $escapedWord . '\b/i', '', $this->string);
         }
 
         $this->compressSpaces();


### PR DESCRIPTION
## Summary
- escape special regex characters in `Strink::removeWords`

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `php /usr/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php` *(fails: PHPUnit 9 does not support attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc1588d7483289b50cfee8ba2634f