### PR TITLE
Document English-only Git metadata policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Indent using 4 spaces and trim trailing whitespace.
 - Ensure each file ends with a newline and stays within 199 characters per line.
 - Write all source code and comments exclusively in English.
+- Ensure all git branch names, tags, commit messages, and related text are written exclusively in English.
 
 ## PHP Guidelines
 


### PR DESCRIPTION
## Summary
- Clarify that all Git branches, tags, commit messages, and related text must be written exclusively in English.

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be6575e09c8328a7426c3b134477aa