### PR TITLE
docs: clarify PHPUnit data provider usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,5 @@
 - Run static analysis using `vendor/bin/phpstan analyse`.
 - Execute unit tests using `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist`.
   For coverage reports, replace `--no-coverage` with `--coverage-clover coverage.xml`.
+- In PHPUnit tests using a data provider, include both the `#[DataProvider(...)]` attribute and the `@dataProvider` annotation.
 


### PR DESCRIPTION
## Summary
- note requirement for both attribute and annotation when using PHPUnit data providers

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be6f3f13008328a3f89a30be67ae4a