### PR TITLE
Fix multibyte handling in limited string truncation

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -145,18 +145,24 @@ class Strink
      */
     public function limitedString(int $limit = 10, string $postText = '...', string $cut = 'right'): self
     {
-        if (strlen($this->string) > $limit) {
+        $stringLength   = mb_strlen($this->string, 'utf-8');
+        $postTextLength = mb_strlen($postText, 'utf-8');
 
+        if ($stringLength > $limit) {
             $limit         = $limit + 1;
             $limitedString = $this->string;
 
             if ($cut == 'right') {
-                $limitedString = mb_substr($this->string, 0, ($limit - strlen($postText)), 'utf-8') . $postText;
-
-            } else if ($cut == 'middle' || $cut == 'center') {
-                $left   = mb_substr($this->string, 0, (ceil($limit / 2) - strlen($postText)), 'utf-8');
+                $limitedString = mb_substr($this->string, 0, ($limit - $postTextLength), 'utf-8') . $postText;
+            } elseif ($cut == 'middle' || $cut == 'center') {
+                $left   = mb_substr($this->string, 0, (ceil($limit / 2) - $postTextLength), 'utf-8');
                 $center = $postText;
-                $right  = mb_substr($this->string, (strlen($this->string) + 1) - (strlen($left) + strlen($center)) + $limit % 2, strlen($this->string), 'utf-8');
+                $right  = mb_substr(
+                    $this->string,
+                    ($stringLength + 1) - (mb_strlen($left, 'utf-8') + mb_strlen($center, 'utf-8')) + $limit % 2,
+                    $stringLength,
+                    'utf-8'
+                );
 
                 $limitedString = $left . $center . $right;
             }

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -149,6 +149,13 @@ class StrinkTest extends TestCase
         $this->assertEquals('short', $Strink->obfuscateString('short', 10));
     }
 
+    public function testLimitedString(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals('Șîĝñ', (string) $Strink->string('Șîĝñ')->limitedString(4));
+        $this->assertEquals('Ș...', (string) $Strink->string('Șîĝñ')->limitedString(3));
+    }
+
     ##########################################################################################################################################################################################
 
     public function testCharacterCasePercentageWithEmptyString(): void


### PR DESCRIPTION
## Summary
- handle multibyte characters correctly in `Strink::limitedString`
- add unit test for multibyte safe truncation

## Testing
- `php -d memory_limit=512M phpstan.phar analyse` *(fails: Found 1536 errors)*
- `/root/.local/share/mise/installs/php/8.4.12/bin/php /usr/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be708b1d408328a08eb9d11e723fdd