### PR TITLE
docs: add branch naming examples to agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@
 - Indent using 4 spaces and trim trailing whitespace.
 - Ensure each file ends with a newline and stays within 199 characters per line.
 - Write all source code and comments exclusively in English.
-- Ensure all git branch names, tags, commit messages, and related text are written exclusively in English.
+- Ensure all git branch names, tags, commit messages, and related text are written exclusively in English. Example:
+  - gresit: `codex/gaseste-si-repara-un-bug-in-cod-u6qdzr`
+  - corect: `codex/find-and-fix-a-bug-in-the-code-u6qdzr`
 
 ## PHP Guidelines
 


### PR DESCRIPTION
## Summary
- document branch naming with correct vs incorrect examples

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be8f239cc88328bb6f970d412cb170