### PR TITLE
docs: add Codex setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,12 @@
   For coverage reports, replace `--no-coverage` with `--coverage-clover coverage.xml`.
 - In PHPUnit tests using a data provider, include both the `#[DataProvider(...)]` attribute and the `@dataProvider` annotation.
 
+## Codex
+
+If you are Codex, before running PHPUnit tests, execute the following commands:
+
+```
+composer create-project symfony/skeleton:7.3 . --no-cache
+composer require symfony/webapp-pack
+```
+


### PR DESCRIPTION
## Summary
- document extra setup steps for Codex in AGENTS guidelines

## Testing
- `composer create-project symfony/skeleton:7.3 . --no-cache` (fails: Project directory is not empty)
- `composer require symfony/webapp-pack` (fails: Installation failed and reverted)
- `composer install` (fails: missing ext-gmp, ext-zend-opcache)
- `vendor/bin/phpstan analyse` (fails: No such file or directory)
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68be9325f6188328aafcb00233e62d8f