### PR TITLE
Fix slugify transliteration and add tests

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -511,7 +511,7 @@ class Strink
 
         // transliterate
         if (!$keepUTF8Chars) {
-            $this->string = $this->transliterateUtf8String($this->string);
+            $this->transliterateUtf8String();
 
             $this->string = preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $this->string);
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -109,6 +109,21 @@ class StrinkTest extends TestCase
         $this->assertEquals('Ora de început', new Strink()->string('Ora de          început')->compressSpaces());
     }
 
+    public function testSlugify(): void
+    {
+        $Strink = new Strink();
+
+        $this->assertEquals(
+            'lorem-ipsum',
+            (string) $Strink->string('Lorem Ipsum')->slugify()
+        );
+
+        $this->assertEquals(
+            'șîĝñ-îñ',
+            (string) $Strink->string('Șîĝñ Îñ')->slugify(true)
+        );
+    }
+
     public function testRemoveNewLines(): void
     {
         $this->assertEquals('LoremIsum', new Strink()->string("Lorem\nIsum")->removeNewLines());


### PR DESCRIPTION
## Summary
- fix slugify transliteration call to use internal state
- add slugify test coverage

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea14e71908328b5d37a6ecb58319d