### PR TITLE
Fix missing data provider attributes in Strink tests

### DIFF
--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -198,6 +198,7 @@ class StrinkTest extends TestCase
     /**
      * @dataProvider dataStrStartsWithAny
      */
+    #[DataProvider('dataStrStartsWithAny')]
     public function testStrStartsWithAny(string $haystack, array $needles, bool $expected): void
     {
         $this->assertEquals($expected, new Strink()->string($haystack)->strStartsWithAny($needles));
@@ -220,6 +221,7 @@ class StrinkTest extends TestCase
     /**
      * @dataProvider dataStrEndsWithAny
      */
+    #[DataProvider('dataStrEndsWithAny')]
     public function testStrEndsWithAny(string $haystack, array $needles, bool $expected): void
     {
         $this->assertEquals($expected, new Strink()->string($haystack)->strEndsWithAny($needles));


### PR DESCRIPTION
## Summary
- add `#[DataProvider]` attributes to data-driven Strink tests

## Testing
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: LogicException: You must set the KERNEL_CLASS environment variable to the fully-qualified class name of your Kernel...)*

------
https://chatgpt.com/codex/tasks/task_e_68bea5cafcd88328bcacf350ea11c094