### PR TITLE
Fix Max-Age cookie expiration handling

### DIFF
--- a/src/Utils/AuroraCookiesExtractor/AuroraCookiesExtractor.php
+++ b/src/Utils/AuroraCookiesExtractor/AuroraCookiesExtractor.php
@@ -82,9 +82,9 @@ class AuroraCookiesExtractor
                 } else {
                     $cookie->setExpires($normalized['expires']);
                 }
-            } else if (isset($normalized['max-age'])) {
-                $cookie->setExpires(new \DateTimeImmutable('@' . (int)$normalized['max-age'], new \DateTimeZone('UTC')));
-            } else if ('PHPSESSID' == $name) {
+            } elseif (isset($normalized['max-age'])) {
+                $cookie->setExpires(new \DateTimeImmutable('@' . (time() + (int) $normalized['max-age']), new \DateTimeZone('UTC')));
+            } elseif ('PHPSESSID' === $name) {
                 // Set expires to 1440 seconds from now (default PHP session.gc_maxlifetime)
                 $cookie->setExpires(new \DateTimeImmutable('+1440 seconds', new \DateTimeZone('UTC')));
             }

--- a/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php
+++ b/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Contracts\HttpClient {
+    interface ResponseInterface {
+        public function getInfo(?string $type = null): mixed;
+    }
+}
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCookiesExtractor {
+    use DateTimeImmutable;
+    use DateTimeZone;
+    use PHPUnit\Framework\TestCase;
+    use Sindla\Bundle\AuroraBundle\Utils\AuroraCookiesExtractor\AuroraCookiesExtractor;
+    use Symfony\Contracts\HttpClient\ResponseInterface;
+
+    class AuroraCookiesExtractorExtractTest extends TestCase
+    {
+        public function testMaxAgeSetsRelativeExpiry(): void
+        {
+            $response = new class implements ResponseInterface {
+                public function getInfo(?string $type = null): mixed
+                {
+                    return [
+                        'response_headers' => ['set-cookie: session=abc; Max-Age=60']
+                    ];
+                }
+            };
+
+            $extractor = new AuroraCookiesExtractor();
+            $cookies = $extractor->extractFromSymfonyResponseInterface($response);
+
+            $this->assertCount(1, $cookies);
+            $expires = $cookies[0]->getExpires();
+            $this->assertInstanceOf(DateTimeImmutable::class, $expires);
+            $diff = $expires->getTimestamp() - (new DateTimeImmutable('now', new DateTimeZone('UTC')))->getTimestamp();
+            $this->assertGreaterThanOrEqual(59, $diff);
+            $this->assertLessThanOrEqual(60, $diff);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix Max-Age cookie handling so expiration is relative to now
- add test covering Max-Age expiration parsing

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php`
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beac3ace1c832896f7d31bda999e96