### PR TITLE
Fix domain matcher handling of malformed URLs

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -7,16 +7,16 @@ class AuroraMatch
     public function matchDomain(string $needle, string $domain): bool
     {
         $parsedNeedle = parse_url($needle);
-        if (array_key_exists('scheme', $parsedNeedle) && array_key_exists('host', $parsedNeedle)) {
+        if (is_array($parsedNeedle) && isset($parsedNeedle['scheme'], $parsedNeedle['host'])) {
             $needle = $parsedNeedle['host'];
         }
 
         $parsedDomain = parse_url($domain);
-        if (array_key_exists('scheme', $parsedDomain) && array_key_exists('host', $parsedDomain)) {
+        if (is_array($parsedDomain) && isset($parsedDomain['scheme'], $parsedDomain['host'])) {
             $domain = $parsedDomain['host'];
         }
 
-        preg_match('/(^|^[^:]+:\/\/|[^\.]+\.)' . preg_quote($domain) . '$/', $needle, $matches);
+        preg_match('/(^|^[^:]+:\/\/|[^\.]+\.)' . preg_quote($domain, '/') . '$/', $needle, $matches);
 
         return ((is_array($matches) && count($matches) > 0 && isset($matches[0]) && !empty($matches[0])) ? true : false);
     }

--- a/tests/Utils/AuroraMatch/InvalidDomainTest.php
+++ b/tests/Utils/AuroraMatch/InvalidDomainTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraMatch;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraMatch\AuroraMatch;
+
+class InvalidDomainTest extends TestCase
+{
+    public function testInvalidUrlInputsDoNotTriggerWarnings(): void
+    {
+        $matcher = new AuroraMatch();
+
+        $this->assertFalse($matcher->matchDomain(':::', 'example.com'));
+        $this->assertFalse($matcher->matchDomain('example.com', ':::'));
+    }
+}


### PR DESCRIPTION
## Summary
- avoid warnings in `AuroraMatch::matchDomain` by guarding against invalid URLs and escaping the regex delimiter
- add regression test for malformed URL input

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: `vendor/bin/phpstan: No such file or directory`)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: `Unable to read the "/workspace/Aurora/.env" environment file.`)*

------
https://chatgpt.com/codex/tasks/task_e_68beb0f5c2288328b928cc1f9539d9bc