### PR TITLE
Fix progress output fallback to Unknown

### DIFF
--- a/src/Tests/WebTestCaseMiddleware.php
+++ b/src/Tests/WebTestCaseMiddleware.php
@@ -91,7 +91,7 @@ class WebTestCaseMiddleware extends WebTestCase
     public function progressAdvance(): void
     {
         if (1 == $this->progressIndex) {
-            fwrite(STDERR, "\nRun " . $this->getParentOrNull() ?? 'Unknown' . "() tests ...\n");
+            fwrite(STDERR, "\nRun " . ($this->getParentOrNull() ?? 'Unknown') . "() tests ...\n");
         }
 
         fwrite(STDERR, '.');

--- a/tests/WebTestCaseMiddlewareTest.php
+++ b/tests/WebTestCaseMiddlewareTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class WebTestCaseMiddlewareTest extends TestCase
+{
+    public function testProgressAdvanceUsesParentName(): void
+    {
+        $code = <<<'CODE'
+        require 'vendor/autoload.php';
+        class Dummy extends \Sindla\Bundle\AuroraBundle\Tests\WebTestCaseMiddleware
+        {
+            protected function getParentOrNull(): ?string
+            {
+                return 'ParentName';
+            }
+            public function run(): void
+            {
+                $this->progressStart(1);
+                $this->progressAdvance();
+            }
+        }
+        (new Dummy())->run();
+        CODE;
+        $output = shell_exec('php -r '.escapeshellarg($code).' 2>&1');
+        $this->assertStringContainsString('Run ParentName() tests', $output);
+    }
+
+    public function testProgressAdvanceFallsBackToUnknown(): void
+    {
+        $code = <<<'CODE'
+        require 'vendor/autoload.php';
+        class Dummy extends \Sindla\Bundle\AuroraBundle\Tests\WebTestCaseMiddleware
+        {
+            protected function getParentOrNull(): ?string
+            {
+                return null;
+            }
+            public function run(): void
+            {
+                $this->progressStart(1);
+                $this->progressAdvance();
+            }
+        }
+        (new Dummy())->run();
+        CODE;
+        $output = shell_exec('php -r '.escapeshellarg($code).' 2>&1');
+        $this->assertStringContainsString('Run Unknown() tests', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure progress reporting uses proper fallback when parent class is missing
- add tests covering progress output

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68beb4b8fa18832896ade931cf76d040