### PR TITLE
Handle multibyte strings in obfuscation

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -127,15 +127,15 @@ class Strink
      */
     public function obfuscateString(mixed $string, int $margins = 2): string
     {
-        $length = strlen($string);
+        $length = mb_strlen($string, 'UTF-8');
 
         if ($margins <= 0 || $length <= $margins * 2) {
             return $string;
         }
 
-        return substr($string, 0, $margins)
+        return mb_substr($string, 0, $margins, 'UTF-8')
             . str_repeat('*', $length - ($margins * 2))
-            . substr($string, -$margins, $margins);
+            . mb_substr($string, -$margins, null, 'UTF-8');
     }
 
     /**

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -162,6 +162,7 @@ class StrinkTest extends TestCase
         $this->assertEquals('my**********ng', $Strink->obfuscateString('mysecretstring', 2));
         $this->assertEquals('myse******ring', $Strink->obfuscateString('mysecretstring', 4));
         $this->assertEquals('short', $Strink->obfuscateString('short', 10));
+        $this->assertEquals('șa*pe', $Strink->obfuscateString('șarpe', 2));
     }
 
     public function testLimitedString(): void


### PR DESCRIPTION
## Summary
- fix Strink::obfuscateString to respect multibyte strings
- cover multibyte obfuscation with a new unit test

## Testing
- `vendor/bin/phpstan analyse` *(fails: Allowed memory size exhausted)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68beba1bb00c832883239788c67cb97e