### PR TITLE
Make parent check methods overridable

### DIFF
--- a/src/Tests/WebTestCaseMiddleware.php
+++ b/src/Tests/WebTestCaseMiddleware.php
@@ -159,12 +159,12 @@ class WebTestCaseMiddleware extends WebTestCase
         return "\e[1;37;41m{$message}\e[0m\n"; // white on red bg
     }
 
-    public function hasParent(): bool
+    protected function hasParent(): bool
     {
         return get_parent_class($this) !== false;
     }
 
-    public function getParentOrNull(): ?string
+    protected function getParentOrNull(): ?string
     {
         $parent = get_parent_class($this);
         return $parent !== false ? $parent : null;


### PR DESCRIPTION
## Summary
- allow overriding WebTestCaseMiddleware::hasParent and ::getParentOrNull by making them protected

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "App\Kernel" doesn't exist or cannot be autoloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68bec9515ed48328a636d826f4e6e71f