### PR TITLE
Fix WebTestCaseMiddleware client type

### DIFF
--- a/src/Tests/WebTestCaseMiddleware.php
+++ b/src/Tests/WebTestCaseMiddleware.php
@@ -5,7 +5,7 @@ namespace Sindla\Bundle\AuroraBundle\Tests;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
-use Symfony\Component\BrowserKit\Tests\TestClient;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -20,7 +20,7 @@ class WebTestCaseMiddleware extends WebTestCase
     /** @var Router */
     protected $router;
 
-    /** @var Client */
+    /** @var KernelBrowser */
     protected $client;
 
     protected $domainName;


### PR DESCRIPTION
## Summary
- correct test middleware to use Symfony's KernelBrowser instead of internal TestClient

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\Bundle\FrameworkBundle\Test\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bece3725808328ba808ad17bc276a8