### PR TITLE
Fix line trimming in Strink linesToArray

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -542,11 +542,11 @@ class Strink
             return [];
         }
 
-        if ($linesArray && $linesArray[0] === '') {
+        while ($linesArray && $linesArray[0] === '') {
             array_shift($linesArray);
         }
 
-        if ($linesArray && end($linesArray) === '') {
+        while ($linesArray && end($linesArray) === '') {
             array_pop($linesArray);
         }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -247,5 +247,11 @@ class StrinkTest extends TestCase
         $this->assertSame(['line1', '', 'line2'], $Strink->string("line1\n\nline2\n")->linesToArray());
     }
 
+    public function testLinesToArrayTrimsEdges(): void
+    {
+        $Strink = new Strink();
+        $this->assertSame(['line1', 'line2'], $Strink->string("\n\nline1\nline2\n\n")->linesToArray());
+    }
+
     ##########################################################################################################################################################################################
 }


### PR DESCRIPTION
## Summary
- ensure `linesToArray` drops all leading and trailing empty lines
- add regression test for `linesToArray`

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bed4386bf08328a62d06d10a81a897