### PR TITLE
refactor: update password validation

### DIFF
--- a/src/Tests/WebTestCaseMiddleware.php
+++ b/src/Tests/WebTestCaseMiddleware.php
@@ -9,7 +9,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\Encoder\EncoderFactory;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class WebTestCaseMiddleware extends WebTestCase
@@ -56,11 +56,10 @@ class WebTestCaseMiddleware extends WebTestCase
      */
     protected function loginWithRawPassword(UserInterface $user, string $rawPassword): void
     {
-        /** @var EncoderFactory $encoderFactory */
-        $encoderFactory = static::getContainer()->get('security.encoder_factory');
-        $encoder        = $encoderFactory->getEncoder($user);
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
 
-        if ($encoder->isPasswordValid($user->getPassword(), $rawPassword, $user->getSalt())) {
+        if ($hasher->isPasswordValid($user, $rawPassword)) {
             $this->loginWithoutValidation($user);
         }
     }


### PR DESCRIPTION
## Summary
- replace deprecated encoder factory with password hasher

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bee30a7e9083289c3dc535067d47f3