### PR TITLE
Fix case-insensitive domain matching

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -16,7 +16,10 @@ class AuroraMatch
             $domain = $parsedDomain['host'];
         }
 
-        preg_match('/(^|^[^:]+:\/\/|[^\.]+\.)' . preg_quote($domain, '/') . '$/', $needle, $matches);
+        $needle = strtolower($needle);
+        $domain = strtolower($domain);
+
+        preg_match('/(^|^[^:]+:\/\/|[^\.]+\.)' . preg_quote($domain, '/') . '$/i', $needle, $matches);
 
         return ((is_array($matches) && count($matches) > 0 && isset($matches[0]) && !empty($matches[0])) ? true : false);
     }
@@ -81,3 +84,4 @@ class AuroraMatch
         return (bool)preg_match($match, $password);
     }
 }
+

--- a/tests/Utils/AuroraMatch/InvalidDomainTest.php
+++ b/tests/Utils/AuroraMatch/InvalidDomainTest.php
@@ -15,4 +15,13 @@ class InvalidDomainTest extends TestCase
         $this->assertFalse($matcher->matchDomain(':::', 'example.com'));
         $this->assertFalse($matcher->matchDomain('example.com', ':::'));
     }
+
+    public function testDomainMatchingIsCaseInsensitive(): void
+    {
+        $matcher = new AuroraMatch();
+
+        $this->assertTrue($matcher->matchDomain('HTTP://WWW.EXAMPLE.COM', 'example.com'));
+        $this->assertTrue($matcher->matchDomain('example.com', 'EXAMPLE.COM'));
+    }
 }
+


### PR DESCRIPTION
## Summary
- handle domains in a case-insensitive way when matching
- add regression test for mixed-case domain matching

## Testing
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraMatch/InvalidDomainTest.php`
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`
- `vendor/bin/phpunit --no-coverage tests/Utils/Twig/UtilityExtensionTest.php`
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf262f9ca0832892d8c913ad1dab3e