### PR TITLE
Fix regex termination in password strength check

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -79,7 +79,7 @@ class AuroraMatch
         }
 
         $match .= ".{{$minLength},{$maxLength}}";
-        $match .= '+$/';
+        $match .= '$/';
 
         return (bool)preg_match($match, $password);
     }


### PR DESCRIPTION
## Summary
- correct password strength regex termination to evaluate strings properly

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: child process error(s) in tests/bootstrap.php, class not found, 1470 errors)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Symfony\Bundle\FrameworkBundle\Test\KernelTestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3a93535c8328a0cc94bb3694ad5a