### PR TITLE
Allow bot detection helpers to accept Request objects

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -238,7 +238,7 @@ class AuroraClient
      *
      * Check if an IPv4 is a Google Bot (by hostname)
      */
-    public function ipIsGoogleBot(string $IP): bool
+    public function ipIsGoogleBot(Request|string $IP): bool
     {
         if ($IP instanceof Request) {
             trigger_error('Method ' . __METHOD__ . ' with Request as parameter is deprecated. Use client Address IP (string) instead.', E_USER_DEPRECATED);
@@ -267,7 +267,7 @@ class AuroraClient
      *
      * Check if an IPv4 is a Microsoft/Bing bot (by hostname)
      */
-    public function ipIsBingBot(string $IP): bool
+    public function ipIsBingBot(Request|string $IP): bool
     {
         if ($IP instanceof Request) {
             trigger_error('Method ' . __METHOD__ . ' with Request as parameter is deprecated. Use client Address IP (string) instead.', E_USER_DEPRECATED);
@@ -294,7 +294,7 @@ class AuroraClient
      *
      * Check if an IPv4 is a Google Bot or a Bing Bot (by hostname)
      */
-    public function ipIsGoogleOrBingBot(string $IP): bool
+    public function ipIsGoogleOrBingBot(Request|string $IP): bool
     {
         return $this->ipIsGoogleBot($IP) || $this->ipIsBingBot($IP);
     }

--- a/tests/Utils/AuroraClient/AuroraClientBotTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientBotTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\HttpFoundation {
+    class Request
+    {
+        public function __construct(
+            array $query = [],
+            array $request = [],
+            array $attributes = [],
+            array $cookies = [],
+            array $files = [],
+            array $server = [],
+            $content = null
+        ) {
+            $this->server = $server;
+        }
+
+        public function getClientIp(): ?string
+        {
+            return $this->server['REMOTE_ADDR'] ?? null;
+        }
+    }
+}
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient {
+    use PHPUnit\Framework\TestCase;
+    use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+    use Symfony\Component\HttpFoundation\Request;
+
+    class AuroraClientBotTest extends TestCase
+    {
+        public function testIpIsGoogleBotAcceptsRequest(): void
+        {
+            $client = new AuroraClient();
+            $ip = '127.0.0.1';
+            $this->assertSame(
+                $client->ipIsGoogleBot($ip),
+                @$client->ipIsGoogleBot(new Request([], [], [], [], [], ['REMOTE_ADDR' => $ip]))
+            );
+        }
+
+        public function testIpIsBingBotAcceptsRequest(): void
+        {
+            $client = new AuroraClient();
+            $ip = '127.0.0.1';
+            $this->assertSame(
+                $client->ipIsBingBot($ip),
+                @$client->ipIsBingBot(new Request([], [], [], [], [], ['REMOTE_ADDR' => $ip]))
+            );
+        }
+
+        public function testIpIsGoogleOrBingBotAcceptsRequest(): void
+        {
+            $client = new AuroraClient();
+            $ip = '127.0.0.1';
+            $this->assertSame(
+                $client->ipIsGoogleOrBingBot($ip),
+                @$client->ipIsGoogleOrBingBot(new Request([], [], [], [], [], ['REMOTE_ADDR' => $ip]))
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- accept Symfony Request in bot-detection helpers
- cover Request handling in bot-detection helpers

## Testing
- `vendor/bin/phpstan analyse` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\Bundle\FrameworkBundle\Test\KernelTestCase" not found)*
- `/root/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit --no-coverage tests/Utils/AuroraClient/AuroraClientBotTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf5095ca5883289aa2aee33ca2e20e