### PR TITLE
Fix timezone handling in dateToHuman

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -58,17 +58,16 @@ class AuroraChronos
     }
 
     /**
-     * Transform/parse a machine date to human date
-     *    eg: 01.09.2013 => 2013-09-01
+     * Transform a machine date to a human date format
+     *    eg: 2013-09-01 => 01.09.2013
      */
-    public function dateToHuman(string|\DateTime $date, string $humanFormat): string
+    public function dateToHuman(string|\DateTimeInterface $date, string $humanFormat): string
     {
-        if (!($date instanceof \DateTime)) {
+        if (!($date instanceof \DateTimeInterface)) {
             $date = new \DateTime($date);
         }
 
-        $parsedDate = date_parse_from_format($humanFormat, $date->format('Y-m-d H:i:s'));
-        return date($humanFormat, $date->getTimestamp());
+        return $date->format($humanFormat);
     }
 
     /**

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -288,4 +288,17 @@ class AuroraChronosTest extends KernelTestCase
         $this->assertSame('00:01', $Chronos->seconds2HM(60));
         $this->assertFalse($Chronos->seconds2HM(-1));
     }
+
+    public function testDateToHumanRespectsTimezone(): void
+    {
+        $previousTz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+
+        $Chronos = new AuroraChronos();
+        $date    = new \DateTime('2010-01-01 12:00:00', new \DateTimeZone('Europe/Bucharest'));
+
+        $this->assertSame('01.01.2010 12:00', $Chronos->dateToHuman($date, 'd.m.Y H:i'));
+
+        date_default_timezone_set($previousTz);
+    }
 }


### PR DESCRIPTION
## Summary
- respect input timezone when formatting machine dates to human-readable strings
- cover timezone-aware conversion with a dedicated test

## Testing
- `composer create-project symfony/skeleton:7.3 temp_project --no-cache` *(fails: Could not find package symfony/skeleton with version 7.3)*
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbc5c52b083289d309aca37074047