### PR TITLE
Fix ISNOTNULL filter condition

### DIFF
--- a/src/Repository/Traits/BaseRepository.php
+++ b/src/Repository/Traits/BaseRepository.php
@@ -386,7 +386,7 @@ trait BaseRepository
                 case 'NOTNULL' :
                 case 'isnotnull' :
                 case 'notnull' :
-                    $queryBuilder->andWhere("UNACCENT({$operation['alias']}.{$operation['field']}) IS NULL");
+                    $queryBuilder->andWhere("UNACCENT({$operation['alias']}.{$operation['field']}) IS NOT NULL");
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- ensure `ISNOTNULL` filters generate `IS NOT NULL` condition

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `composer create-project symfony/skeleton:7.3 temp_project --no-cache` *(fails: package not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbe8a0a5883288dc2dfd04cba3508