### PR TITLE
Fix random string generation for zero length

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -88,15 +88,20 @@ class Strink
      *
      * @param integer     $length
      * @param multi-array $keysToUse
-     */
+    */
     public function randomString(int $length = 12, array $keysToUse = []): self
     {
+        if ($length <= 0) {
+            $this->string = '';
+            return $this;
+        }
+
         if (is_array($keysToUse) && count($keysToUse) == 0) {
             $keysToUse = [
                 'abcdefghijklmnopqrstuwxyz',
                 'ABCDEFGHIJKLMNOPQRSTUWXYZ',
                 '0123456789',
-                '!@#$%^&*+='
+                '!@#$%^&*+=' 
             ];
         }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -253,5 +253,11 @@ class StrinkTest extends TestCase
         $this->assertSame(['line1', 'line2'], $Strink->string("\n\nline1\nline2\n\n")->linesToArray());
     }
 
+    public function testRandomStringZeroLength(): void
+    {
+        $Strink = new Strink();
+        $this->assertSame('', (string) $Strink->randomString(0));
+    }
+
     ##########################################################################################################################################################################################
 }


### PR DESCRIPTION
## Summary
- avoid generating characters when requested length is zero
- test zero-length random string handling

## Testing
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` (fails: KERNEL_CLASS environment variable not set, numerous errors)
- `vendor/bin/phpstan analyse` (fails: vendor/bin/phpstan: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68bfc1b55d748328b332760fd30b547e