### PR TITLE
Fix padding of time components in dateToMachineDateTime

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -54,7 +54,12 @@ class AuroraChronos
     public function dateToMachineDateTime(string $datetime, string $humanFormat): string
     {
         $parsedDate = date_parse_from_format($humanFormat, $datetime);
-        return $parsedDate['year'] . '-' . str_pad($parsedDate['month'], 2, 0, STR_PAD_LEFT) . '-' . str_pad($parsedDate['day'], 2, 0, STR_PAD_LEFT) . ' ' . (!empty($parsedDate['hour']) ? $parsedDate['hour'] : '00') . ':' . (!empty($parsedDate['minute']) ? $parsedDate['minute'] : '00') . ':' . (!empty($parsedDate['second']) ? $parsedDate['second'] : '00');
+
+        $hour   = str_pad((string)($parsedDate['hour'] ?? 0), 2, '0', STR_PAD_LEFT);
+        $minute = str_pad((string)($parsedDate['minute'] ?? 0), 2, '0', STR_PAD_LEFT);
+        $second = str_pad((string)($parsedDate['second'] ?? 0), 2, '0', STR_PAD_LEFT);
+
+        return $parsedDate['year'] . '-' . str_pad($parsedDate['month'], 2, 0, STR_PAD_LEFT) . '-' . str_pad($parsedDate['day'], 2, 0, STR_PAD_LEFT) . ' ' . $hour . ':' . $minute . ':' . $second;
     }
 
     /**

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -164,6 +164,24 @@ class AuroraChronosTest extends KernelTestCase
         }
     }
 
+    #[DataProvider('dataDateToMachineDateTime')]
+    /** @dataProvider dataDateToMachineDateTime */
+    public function testDateToMachineDateTime(string $expected, array $given): void
+    {
+        $this->assertSame(
+            $expected,
+            (new AuroraChronos())->dateToMachineDateTime($given[0], $given[1])
+        );
+    }
+
+    public static function dataDateToMachineDateTime(): array
+    {
+        return [
+            ['2010-02-01 01:02:03', ['01.02.2010 1:2:3', 'd.m.Y H:i:s']],
+            ['2010-02-01 00:00:00', ['01.02.2010', 'd.m.Y']],
+        ];
+    }
+
     public function testSecondsBetweenTwoDates()
     {
         $Chronos = new AuroraChronos();


### PR DESCRIPTION
## Summary
- pad hour, minute and second fields when converting a human datetime string to machine format
- cover dateToMachineDateTime with new test cases

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc868dc5483289927ec4bcbb41564