### PR TITLE
Handle unformatted times in dateToMachineDateTime

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -55,6 +55,10 @@ class AuroraChronos
     {
         $parsedDate = date_parse_from_format($humanFormat, $datetime);
 
+        if (($parsedDate['error_count'] ?? 0) > 0) {
+            return date('Y-m-d H:i:s', strtotime($datetime));
+        }
+
         $hour   = str_pad((string)($parsedDate['hour'] ?? 0), 2, '0', STR_PAD_LEFT);
         $minute = str_pad((string)($parsedDate['minute'] ?? 0), 2, '0', STR_PAD_LEFT);
         $second = str_pad((string)($parsedDate['second'] ?? 0), 2, '0', STR_PAD_LEFT);


### PR DESCRIPTION
## Summary
- fall back to `strtotime` when parsing fails in `dateToMachineDateTime`

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Found 1538 errors)*
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraChronos/AuroraChronosTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfd98987e483288e57a6bdd5f28798