### PR TITLE
Fix AuroraIP test namespace and annotations

### DIFF
--- a/tests/Utils/AuroraIP/AuroraIPTest.php
+++ b/tests/Utils/AuroraIP/AuroraIPTest.php
@@ -1,14 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient;
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraIP;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraIP\AuroraIP;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\HttpClient\HttpClient;
 
 /**
  * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraIP/AuroraIPTest.php --no-coverage
@@ -30,6 +27,9 @@ class AuroraIPTest extends KernelTestCase
         $this->assertFalse(false);
     }
 
+    /**
+     * @dataProvider dataIsGoogleBot
+     */
     #[DataProvider('dataIsGoogleBot')]
     public function testIsGoogleBot(string $given, bool $expected): void
     {
@@ -54,6 +54,9 @@ class AuroraIPTest extends KernelTestCase
         ];
     }
 
+    /**
+     * @dataProvider dataIsPrivate
+     */
     #[DataProvider('dataIsPrivate')]
     public function testIsPrivate(string $given, bool $expected): void
     {


### PR DESCRIPTION
## Summary
- fix incorrect namespace and clean up imports in `AuroraIPTest`
- add missing `@dataProvider` annotations for test methods

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe1aab7bc83288873b0b5bb20d42b