### PR TITLE
Replace BigDecimal usage in Strink utility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ext-tokenizer": "*",
         "ext-zend-opcache": "*",
         "aws/aws-sdk-php": "3.*",
-        "brick/math": "0.13.*",
         "doctrine/orm": "^3.3",
         "firebase/php-jwt": "6.*",
         "geoip2/geoip2": "3.2.*",

--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -2,8 +2,6 @@
 
 namespace Sindla\Bundle\AuroraBundle\Utils\Strink;
 
-use Brick\Math\BigDecimal;
-use Brick\Math\RoundingMode;
 
 class Strink
 {
@@ -608,10 +606,7 @@ class Strink
 
         $lower = $this->countLowerCharacters();
 
-        return BigDecimal::of($lower)
-            ->dividedBy($total, 2, RoundingMode::HALF_UP)
-            ->multipliedBy(100)
-            ->toFloat();
+        return round(($lower / $total) * 100, 2);
     }
 
     public function countUpperCharacters(): int
@@ -631,10 +626,7 @@ class Strink
 
         $upper = $this->countUpperCharacters();
 
-        return BigDecimal::of($upper)
-            ->dividedBy($total, 2, RoundingMode::HALF_UP)
-            ->multipliedBy(100)
-            ->toFloat();
+        return round(($upper / $total) * 100, 2);
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid dependency on Brick\Math for character case percentage calculations
- remove unused `brick/math` requirement

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "App\Kernel" doesn't exist or cannot be autoloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68c00e7b80ac832897158683713570e6