### PR TITLE
Replace undefined array_any in Strink helpers

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -639,12 +639,24 @@ class Strink
 
     public function strStartsWithAny(array $needles): bool
     {
-        return \array_any($needles, fn($needle, $_) => is_string($needle) && str_starts_with($this->string, $needle));
+        foreach ($needles as $needle) {
+            if (is_string($needle) && str_starts_with($this->string, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function strEndsWithAny(array $needles): bool
     {
-        return \array_any($needles, fn($needle, $_) => is_string($needle) && str_ends_with($this->string, $needle));
+        foreach ($needles as $needle) {
+            if (is_string($needle) && str_ends_with($this->string, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function __toString(): string


### PR DESCRIPTION
## Summary
- replace PHP 8.4 array_any usage with manual loops in string prefix/suffix helpers

## Testing
- `composer install` *(fails: requires ext-gmp and ext-zend-opcache)*
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c01cc17b8c8328b92b1d2943a71e6d