### PR TITLE
Fix twig extension dnsPrefetch handler

### DIFF
--- a/src/Utils/Twig/UtilityExtension.php
+++ b/src/Utils/Twig/UtilityExtension.php
@@ -108,7 +108,7 @@ class UtilityExtension extends AbstractExtension
             // {{ aurora.pwa.unregister(app.request, app.debug) }}
             new TwigFunction('pwa.unregister', [$this, 'pwaUnregister']),
 
-            new TwigFunction('dnsPrefetch', [$this, 'dnsPrefach']),
+            new TwigFunction('dnsPrefetch', [$this, 'dnsPrefetch']),
 
             new TwigFunction('linkRelDnsPrefetch', [$this, 'linkRelDnsPrefetch']),
             new TwigFunction('linkRelPreload', [$this, 'linkRelPreload']),


### PR DESCRIPTION
## Summary
- correct `dnsPrefetch` twig function to call the proper `dnsPrefetch` method

## Testing
- `composer create-project symfony/skeleton:7.3 temp_project --no-cache` *(fails: Could not find package symfony/skeleton with version 7.3)*
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c01e9cc35083289988bc3cc7fb9254