### PR TITLE
Fix quote compression logic

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -77,7 +77,7 @@ class Strink
      */
     public function compressQuotes(): self
     {
-        $this->string = $this
+        $this
             ->compressSimpleQuotes()
             ->compressDoubleQuotes()
             ->compressSimpleQuotes()

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -114,6 +114,22 @@ class StrinkTest extends TestCase
         $this->assertEquals("\"Pleașe țest thîs string\"", new Strink()->string("\"\"Pleașe țest thîs string\"\"")->compressDoubleQuotes());
     }
 
+    public function testCompressQuotes(): void
+    {
+        $raw = "\"\"''Test''\"\"";
+        $expected = (string) (new Strink())
+            ->string($raw)
+            ->compressSimpleQuotes()
+            ->compressDoubleQuotes()
+            ->compressSimpleQuotes()
+            ->compressDoubleQuotes();
+
+        $this->assertEquals(
+            $expected,
+            (string) (new Strink())->string($raw)->compressQuotes()
+        );
+    }
+
     public function testSlugify(): void
     {
         $Strink = new Strink();


### PR DESCRIPTION
## Summary
- avoid assigning object to string when compressing quotes
- cover quote compression with a dedicated test

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c0459e9ea48328b378afbafc058f6b