### PR TITLE
Handle CRLF correctly when removing newlines

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -32,7 +32,7 @@ class Strink
 
     public function removeNewLines(string $replaceWith = ''): self
     {
-        $this->string = str_replace(["\r", "\n"], $replaceWith, $this->string);
+        $this->string = str_replace(["\r\n", "\r", "\n"], $replaceWith, $this->string);
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -157,6 +157,10 @@ class StrinkTest extends TestCase
         $this->assertEquals('Lorem  Isum', new Strink()->string("Lorem\n\nIsum")->removeNewLines("\x20"));
         $this->assertEquals('  Lorem  Isum  ', new Strink()->string("\n\nLorem\n\nIsum\n\n")->removeNewLines("\x20"));
 
+        $this->assertEquals('LoremIsum', new Strink()->string("Lorem\r\nIsum")->removeNewLines());
+        $this->assertEquals('Lorem Isum', new Strink()->string("Lorem\r\nIsum")->removeNewLines("\x20"));
+        $this->assertEquals(' Lorem Isum ', new Strink()->string("\r\nLorem\r\nIsum\r\n")->removeNewLines("\x20"));
+
         $this->assertEquals('LoremIsum', new Strink()->string("Lorem\rIsum")->removeNewLines());
         $this->assertEquals('LoremIsum', new Strink()->string("\rLorem\rIsum\r")->removeNewLines());
         $this->assertEquals('LoremIsum', new Strink()->string("Lorem\r\rIsum")->removeNewLines());


### PR DESCRIPTION
## Summary
- ensure `Strink::removeNewLines` treats Windows CRLF as a single newline
- cover CRLF handling with additional tests

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: class not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: KernelTestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0502938508328832387528f07a991