### PR TITLE
Handle multibyte characters in snakeCaseToHumanCase

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -208,11 +208,18 @@ class Strink
      */
     public function snakeCaseToHumanCase(bool $upperCaseFirstLetter = false, bool $upperCaseAllLetters = false): self
     {
-        $this->string = strtolower($this->string);
+        $encoding = $this->detectEncoding();
 
+        $this->string = mb_strtolower($this->string, $encoding);
         $this->string = str_replace('_', ' ', $this->string);
-        $this->string = ($upperCaseFirstLetter ? ucfirst($this->string) : $this->string);
-        $this->string = ($upperCaseAllLetters ? ucwords($this->string) : $this->string);
+
+        if ($upperCaseAllLetters) {
+            $this->string = mb_convert_case($this->string, MB_CASE_TITLE, $encoding);
+        } elseif ($upperCaseFirstLetter) {
+            $this->string = mb_strtoupper(mb_substr($this->string, 0, 1, $encoding), $encoding)
+                . mb_substr($this->string, 1, null, $encoding);
+        }
+
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -84,7 +84,8 @@ class StrinkTest extends TestCase
         }
 
         foreach ([
-                     'External Request Repository' => ['external_request_repository']
+                     'External Request Repository' => ['external_request_repository'],
+                     'Șîĝñ Îñ'                    => ['ȘÎĞÑ_ÎÑ']
                  ] as $expected => $givens) {
             foreach ($givens as $given) {
                 $this->assertEquals(


### PR DESCRIPTION
## Summary
- ensure snakeCaseToHumanCase uses multibyte string functions
- cover multibyte scenario in tests

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `composer create-project symfony/skeleton:7.3 temp_project --no-cache` *(fails: Could not find package symfony/skeleton with version 7.3)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c082d34ad88328a11d8776059f4555