### PR TITLE
Fix hour difference calculation

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -215,8 +215,7 @@ class AuroraChronos
             }
         }
 
-        $interval = $startDate->diff($endDate);
-        return $interval->format('%r%h');
+        return intdiv($endDate->getTimestamp() - $startDate->getTimestamp(), 3600);
     }
 
     /**


### PR DESCRIPTION
## Summary
- compute hour differences using timestamps to include full day spans

## Testing
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan: No such file or directory)*
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\Bundle\FrameworkBundle\Test\KernelTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c090415254832887a61b48ed3d7a19