### PR TITLE
Correct diacritic in snakeCaseToHumanCase test

### DIFF
--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -85,7 +85,7 @@ class StrinkTest extends TestCase
 
         foreach ([
                      'External Request Repository' => ['external_request_repository'],
-                     'Șîĝñ Îñ'                    => ['ȘÎĞÑ_ÎÑ']
+                     'Șîğñ Îñ'                    => ['ȘÎĞÑ_ÎÑ']
                  ] as $expected => $givens) {
             foreach ($givens as $given) {
                 $this->assertEquals(


### PR DESCRIPTION
## Summary
- fix expected output for `snakeCaseToHumanCase` diacritic conversion

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: PHPStan process crashed because it reached configured PHP memory limit)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Sindla\Bundle\AuroraBundle\Tests\WebTestCaseMiddleware" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10c7aeb208328901952a8526109ae