### PR TITLE
Rename IP validation helper

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -167,7 +167,7 @@ class AuroraClient
         if (
             isset($_SERVER['HTTP_X_FORWARDED_FOR'])
             && false === strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',')
-            && $this->ipIsValide($_SERVER['HTTP_X_FORWARDED_FOR'])
+            && $this->ipIsValid($_SERVER['HTTP_X_FORWARDED_FOR'])
         ) {
             return $_SERVER['HTTP_X_FORWARDED_FOR'];
         }
@@ -175,21 +175,21 @@ class AuroraClient
         if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') !== false) {
             foreach (explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']) as $ip) {
                 $ip = trim($ip);
-                if ($this->ipIsValide($ip)) {
+                if ($this->ipIsValid($ip)) {
                     return $ip;
                 }
             }
         }
 
-        if ($this->ipIsValide($request->getClientIp())) {
+        if ($this->ipIsValid($request->getClientIp())) {
             return $request->getClientIp();
         }
 
-        if (isset($_SERVER['HTTP_CLIENT_IP']) && $this->ipIsValide($_SERVER['HTTP_CLIENT_IP'])) {
+        if (isset($_SERVER['HTTP_CLIENT_IP']) && $this->ipIsValid($_SERVER['HTTP_CLIENT_IP'])) {
             return $_SERVER['HTTP_CLIENT_IP'];
         }
 
-        if (isset($_SERVER['REMOTE_ADDR']) && $this->ipIsValide($_SERVER['REMOTE_ADDR'])) {
+        if (isset($_SERVER['REMOTE_ADDR']) && $this->ipIsValid($_SERVER['REMOTE_ADDR'])) {
             return $_SERVER['REMOTE_ADDR'];
         }
 
@@ -199,7 +199,7 @@ class AuroraClient
     /**
      * Check if an IP is valid
      */
-    public function ipIsValide(mixed $ip): bool
+    public function ipIsValid(mixed $ip): bool
     {
         $ipIsValid = filter_var(
             $ip,

--- a/tests/Utils/AuroraClient/AuroraClientTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientTest.php
@@ -33,17 +33,17 @@ class AuroraClientTest extends KernelTestCase
         $this->assertFalse(false);
     }
 
-    public function testIpIsValideAcceptsIpv6(): void
+    public function testIpIsValidAcceptsIpv6(): void
     {
         $client = new AuroraClient($this->containerTest);
 
         $this->assertTrue(
-            $client->ipIsValide('2001:4860:4860::8888'),
+            $client->ipIsValid('2001:4860:4860::8888'),
             'Expected a public IPv6 address to be considered valid.'
         );
 
         $this->assertFalse(
-            $client->ipIsValide('::1'),
+            $client->ipIsValid('::1'),
             'Loopback IPv6 address should be considered invalid.'
         );
     }


### PR DESCRIPTION
## Summary
- rename `ipIsValide` to `ipIsValid` to use correct English spelling
- update IPv6 validation test for renamed method

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c10f4dec248328a1695ba469365bd9