### PR TITLE
Fix WebTestCaseMiddleware tests to avoid overriding final run

### DIFF
--- a/tests/WebTestCaseMiddlewareTest.php
+++ b/tests/WebTestCaseMiddlewareTest.php
@@ -18,13 +18,13 @@ class WebTestCaseMiddlewareTest extends TestCase
             {
                 return 'ParentName';
             }
-            public function run(): void
+            public function execute(): void
             {
                 $this->progressStart(1);
                 $this->progressAdvance();
             }
         }
-        (new Dummy())->run();
+        (new Dummy('test'))->execute();
         CODE;
         $output = shell_exec('php -r '.escapeshellarg($code).' 2>&1');
         $this->assertStringContainsString('Run ParentName() tests', $output);
@@ -40,13 +40,13 @@ class WebTestCaseMiddlewareTest extends TestCase
             {
                 return null;
             }
-            public function run(): void
+            public function execute(): void
             {
                 $this->progressStart(1);
                 $this->progressAdvance();
             }
         }
-        (new Dummy())->run();
+        (new Dummy('test'))->execute();
         CODE;
         $output = shell_exec('php -r '.escapeshellarg($code).' 2>&1');
         $this->assertStringContainsString('Run Unknown() tests', $output);
@@ -62,7 +62,7 @@ class WebTestCaseMiddlewareTest extends TestCase
             {
                 return 'ParentName';
             }
-            public function run(): void
+            public function execute(): void
             {
                 $this->progressStart(1);
                 $this->progressAdvance();
@@ -70,7 +70,7 @@ class WebTestCaseMiddlewareTest extends TestCase
                 $this->progressAdvance();
             }
         }
-        (new Dummy())->run();
+        (new Dummy('test'))->execute();
         CODE;
         $output = shell_exec('php -r '.escapeshellarg($code).' 2>&1');
         $this->assertSame(2, substr_count($output, 'Run ParentName() tests'));


### PR DESCRIPTION
## Summary
- avoid overriding PHPUnit's final `run()` in WebTestCaseMiddleware tests by using a custom `execute()` method
- construct dummy test classes with a name to satisfy PHPUnit

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: 71 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c113312c108328a341b7023af2df0e