### PR TITLE
Handle missing WebTestCase dependency gracefully

### DIFF
--- a/src/Tests/WebTestCaseMiddleware.php
+++ b/src/Tests/WebTestCaseMiddleware.php
@@ -11,6 +11,11 @@ use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists(WebTestCase::class)) {
+    class_alias(TestCase::class, WebTestCase::class);
+}
 
 class WebTestCaseMiddleware extends WebTestCase
 {


### PR DESCRIPTION
## Summary
- Avoid fatal errors when `symfony/framework-bundle` is absent by aliasing `WebTestCase` to PHPUnit's `TestCase`

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Symfony\Bundle\FrameworkBundle\Test\KernelTestCase not found)*
- `vendor/bin/phpunit --no-coverage tests/WebTestCaseMiddlewareTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1363f82c48328be56367a8f4c504e