### PR TITLE
docs: require running tests for PHP changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Execute unit tests using `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist`.
   For coverage reports, replace `--no-coverage` with `--coverage-clover coverage.xml`.
 - In PHPUnit tests using a data provider, include both the `#[DataProvider(...)]` attribute and the `@dataProvider` annotation.
+- When a PHP file (class, method, trait, etc.) is modified, verify and run all existing PHPUnit tests for that file before completing the task and finish only if these tests pass.
 
 ## Codex
 


### PR DESCRIPTION
## Summary
- clarify AGENTS testing instructions: run PHPUnit tests for modified PHP files before completing tasks

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c13e10c7ac8328b686c01d520b9b77