### PR TITLE
Handle cookie headers case-insensitively

### DIFF
--- a/src/Utils/AuroraCookiesExtractor/AuroraCookiesExtractor.php
+++ b/src/Utils/AuroraCookiesExtractor/AuroraCookiesExtractor.php
@@ -17,7 +17,8 @@ class AuroraCookiesExtractor
         }
 
         foreach ($response['response_headers'] as $header) {
-            if (!str_starts_with($header, 'set-cookie:')) {
+            $lowerHeader = strtolower($header);
+            if (!str_starts_with($lowerHeader, 'set-cookie:')) {
                 continue;
             }
 

--- a/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php
+++ b/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php
@@ -37,5 +37,24 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCookiesExtractor {
             $this->assertGreaterThanOrEqual(59, $diff);
             $this->assertLessThanOrEqual(60, $diff);
         }
+
+        public function testHeaderCaseInsensitive(): void
+        {
+            $response = new class implements ResponseInterface {
+                public function getInfo(?string $type = null): mixed
+                {
+                    return [
+                        'response_headers' => ['Set-Cookie: test=1']
+                    ];
+                }
+            };
+
+            $extractor = new AuroraCookiesExtractor();
+            $cookies = $extractor->extractFromSymfonyResponseInterface($response);
+
+            $this->assertCount(1, $cookies);
+            $this->assertSame('test', $cookies[0]->getName());
+            $this->assertSame('1', $cookies[0]->getValue());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle Set-Cookie headers case-insensitively when extracting cookies
- cover header case handling with new unit test

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php`
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorTest.php`
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1476e9c888328842116d47ad48042