### PR TITLE
Fix UTF-8 word removal in Strink utility

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -262,7 +262,7 @@ class Strink
     {
         foreach ($wordsList as $word) {
             $escapedWord = preg_quote($word, '/');
-            $this->string = preg_replace('/\b' . $escapedWord . '\b/i', '', $this->string);
+            $this->string = preg_replace('/\b' . $escapedWord . '\b/iu', '', $this->string);
         }
 
         $this->compressSpaces();

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -182,6 +182,20 @@ class StrinkTest extends TestCase
         $this->assertEquals('Șarpe', (string) $Strink->string('șarpe')->ucfirst());
     }
 
+    public function testRemoveWords(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals(
+            'maro',
+            (string) $Strink->string('șarpe maro')->removeWords(['șarpe'])
+        );
+
+        $this->assertEquals(
+            'Lorem ipsum',
+            (string) $Strink->string('Lorem ipsum dolor')->removeWords(['dolor'])
+        );
+    }
+
     public function testObfuscateString(): void
     {
         $Strink = new Strink();


### PR DESCRIPTION
## Summary
- handle UTF-8 characters when removing words in Strink
- cover word removal with tests for accented and ASCII input

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Found 1074 errors)*
- `vendor/bin/phpunit --no-coverage phpunit.xml.dist` *(fails: 70 errors, environment misconfiguration)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c15256beb88328a11be8d9db8b4b7c