### PR TITLE
Fix HTTPS detection in AuroraClient protocol method

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -136,9 +136,13 @@ class AuroraClient
         // Reverse proxy
         if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
             return $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://';
-        } else {
-            return !empty($_SERVER['HTTPS']) ? "https://" : "http://";
         }
+
+        if (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off') {
+            return 'https://';
+        }
+
+        return 'http://';
     }
 
     /**
@@ -146,11 +150,7 @@ class AuroraClient
      */
     public function isSSL(): bool
     {
-        if (preg_match('/https/i', $this->protocol())) {
-            return true;
-        } else {
-            return false;
-        }
+        return preg_match('/https/i', $this->protocol()) === 1;
     }
 
     /**

--- a/tests/Utils/AuroraClient/AuroraClientTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientTest.php
@@ -48,6 +48,26 @@ class AuroraClientTest extends KernelTestCase
         );
     }
 
+    public function testProtocolAndIsSSL(): void
+    {
+        $client = new AuroraClient($this->containerTest);
+
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+        $this->assertSame('https://', $client->protocol());
+        $this->assertTrue($client->isSSL());
+        unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
+
+        $_SERVER['HTTPS'] = 'on';
+        $this->assertSame('https://', $client->protocol());
+        $this->assertTrue($client->isSSL());
+
+        $_SERVER['HTTPS'] = 'off';
+        $this->assertSame('http://', $client->protocol());
+        $this->assertFalse($client->isSSL());
+
+        unset($_SERVER['HTTPS']);
+    }
+
     public function __SKIP__testIP2CountryCode()
     {
         $Client = new AuroraClient($this->containerTest);


### PR DESCRIPTION
## Summary
- Correct protocol detection when `$_SERVER['HTTPS']` is `'off'`
- Simplify SSL check logic
- Add tests for protocol and SSL detection

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1581afa048328953302b6b254497c