### PR TITLE
Fix extra semicolon in PHPUnit badge generation

### DIFF
--- a/src/Utils/AuroraPHPUnitCodeCoverageBadge/AuroraPHPUnitCodeCoverageBadge.php
+++ b/src/Utils/AuroraPHPUnitCodeCoverageBadge/AuroraPHPUnitCodeCoverageBadge.php
@@ -26,7 +26,7 @@ class AuroraPHPUnitCodeCoverageBadge
             $colorB = '#CB2431';  // Red
         }
 
-        $PHPUnitSVG = $this->_PHPUnitPassingBadge($passedTests, $testsTotal, $colorA, $colorB);;
+        $PHPUnitSVG = $this->_PHPUnitPassingBadge($passedTests, $testsTotal, $colorA, $colorB);
         file_put_contents($outputSVGFilePath, $PHPUnitSVG);
     }
 


### PR DESCRIPTION
## Summary
- remove duplicate semicolon when generating PHPUnit badge

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c169e7e7948328bfc96891e306b9af