### PR TITLE
Trim Accept-Language values

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -221,8 +221,8 @@ class AuroraClient
             $prefLanguages = array_reduce(
                 explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']),
                 function ($res, $el) {
-                    [$l, $q] = array_merge(explode(';q=', $el), [1]);
-                    $res[$l] = (float)$q;
+                    [$l, $q] = array_merge(explode(';q=', trim($el)), [1]);
+                    $res[trim($l)] = (float) $q;
                     return $res;
                 }, []);
             arsort($prefLanguages);

--- a/tests/Utils/AuroraClient/AuroraClientTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientTest.php
@@ -68,6 +68,23 @@ class AuroraClientTest extends KernelTestCase
         unset($_SERVER['HTTPS']);
     }
 
+    public function testPreferredLanguagesTrimsSpaces(): void
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US, en;q=0.5,fr;q=0.7';
+        $client                          = new AuroraClient($this->containerTest);
+
+        $this->assertSame(
+            [
+                'en-US' => 1.0,
+                'fr'    => 0.7,
+                'en'    => 0.5,
+            ],
+            $client->preferredLanguages()
+        );
+
+        unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+    }
+
     public function __SKIP__testIP2CountryCode()
     {
         $Client = new AuroraClient($this->containerTest);


### PR DESCRIPTION
## Summary
- trim spaces when parsing HTTP_ACCEPT_LANGUAGE for preferred languages
- test preferredLanguages trims spaces

## Testing
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraClient/AuroraClientTest.php` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1756f39988328bfd082f82e01c76f