### PR TITLE
Refactor domain matching and simplify tests

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -26,15 +26,13 @@ class AuroraMatch
 
     public function matchAtLeastOneDomain(string $needle, array $domains): bool
     {
-        $matched = false;
-
         foreach ($domains as $domain) {
             if ($this->matchDomain($needle, $domain)) {
-                $matched = true;
+                return true;
             }
         }
 
-        return $matched;
+        return false;
     }
 
     public function matchCssUrls(string $css, bool $relativeUrlOnly = true): array

--- a/tests/Utils/AuroraMatch/AuroraMatchTest.php
+++ b/tests/Utils/AuroraMatch/AuroraMatchTest.php
@@ -6,25 +6,14 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraMatch;
 // PHPUnit
 use PHPUnit\Framework\TestCase;
 
-// Symfony
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-
 // Aurora
 use Sindla\Bundle\AuroraBundle\Utils\AuroraMatch\AuroraMatch;
 
 /**
  * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraMatch/AuroraMatchTest.php --no-coverage
  */
-class AuroraMatchTest extends KernelTestCase
+class AuroraMatchTest extends TestCase
 {
-    private $kernelTest;
-    private $containerTest;
-
-    protected function setUp(): void
-    {
-        $this->kernelTest    = self::bootKernel();
-        $this->containerTest = $this->kernelTest->getContainer();
-    }
 
     public function testFake(): void
     {
@@ -32,7 +21,7 @@ class AuroraMatchTest extends KernelTestCase
         $this->assertFalse(false);
     }
 
-    private function _matchDomain()
+    private function _matchDomain(): array
     {
         return [
             # true ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- avoid unnecessary iteration when checking multiple domains
- remove kernel dependency from AuroraMatch tests

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraMatch/AuroraMatchTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c1994aa9a48328983225cca7242d34