### PR TITLE
Fix UTF-8 camel case conversion

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -196,8 +196,13 @@ class Strink
      */
     public function snakeCaseToCamelCase(bool $upperCaseFirstLetter = false): self
     {
-        $this->string = str_replace('_', '', ucwords($this->string, '_'));
-        $this->string = !$upperCaseFirstLetter ? lcfirst($this->string) : $this->string;
+        $encoding     = $this->detectEncoding();
+        $this->string = str_replace('_', '', mb_convert_case($this->string, MB_CASE_TITLE, $encoding));
+
+        if (!$upperCaseFirstLetter) {
+            $this->string = mb_strtolower(mb_substr($this->string, 0, 1, $encoding), $encoding)
+                . mb_substr($this->string, 1, null, $encoding);
+        }
 
         return $this;
     }

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -66,6 +66,10 @@ class StrinkTest extends TestCase
                 $this->assertEquals($expected, $Strink->string($given)->snakeCaseToCamelCase(upperCaseFirstLetter: false));
             }
         }
+
+        // UTF-8 support
+        $this->assertEquals('ȘarpeMagic', $Strink->string('șarpe_magic')->snakeCaseToCamelCase(upperCaseFirstLetter: true));
+        $this->assertEquals('șarpeMagic', $Strink->string('șarpe_magic')->snakeCaseToCamelCase(upperCaseFirstLetter: false));
     }
 
     public function testSnakeCaseToHumanCase(): void


### PR DESCRIPTION
## Summary
- handle UTF-8 characters when converting snake_case to camelCase
- cover non-ASCII snake_case to camelCase in tests

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` (fails: Class Symfony\Component\Dotenv\Dotenv not found)
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c19eb529c48328b5831d6ba6fd167e