### PR TITLE
Ignore empty needles in Strink prefix and suffix checks

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -652,7 +652,7 @@ class Strink
     public function strStartsWithAny(array $needles): bool
     {
         foreach ($needles as $needle) {
-            if (is_string($needle) && str_starts_with($this->string, $needle)) {
+            if (is_string($needle) && $needle !== '' && str_starts_with($this->string, $needle)) {
                 return true;
             }
         }
@@ -663,7 +663,7 @@ class Strink
     public function strEndsWithAny(array $needles): bool
     {
         foreach ($needles as $needle) {
-            if (is_string($needle) && str_ends_with($this->string, $needle)) {
+            if (is_string($needle) && $needle !== '' && str_ends_with($this->string, $needle)) {
                 return true;
             }
         }

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -258,6 +258,7 @@ class StrinkTest extends TestCase
             ['lorem ipsum', ['ipsum', 'dolor'], false],
             ['lorem ipsum', ['ipsum lorem'], false],
             ['lorem ipsum', ['lorem ipsum dolor'], false],
+            ['lorem ipsum', [''], false],
         ];
     }
 
@@ -281,6 +282,7 @@ class StrinkTest extends TestCase
             ['lorem ipsum', ['lorem', 'dolor'], false],
             ['lorem ipsum', ['lorem ipsum'], true],
             ['lorem ipsum', ['lorem ipsum dolor'], false],
+            ['lorem ipsum', [''], false],
         ];
     }
 


### PR DESCRIPTION
## Summary
- avoid treating empty strings as valid needles in `Strink::strStartsWithAny`
- avoid treating empty strings as valid needles in `Strink::strEndsWithAny`
- add regression tests for prefix and suffix helpers

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c24ce09ff083288851e2221b634ca0