### PR TITLE
Handle non-string input in obfuscateString

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -135,6 +135,7 @@ class Strink
      */
     public function obfuscateString(mixed $string, int $margins = 2): string
     {
+        $string = (string) $string;
         $length = mb_strlen($string, 'UTF-8');
 
         if ($margins <= 0 || $length <= $margins * 2) {

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -200,13 +200,25 @@ class StrinkTest extends TestCase
         );
     }
 
-    public function testObfuscateString(): void
+    /**
+     * @dataProvider dataObfuscateString
+     */
+    #[DataProvider('dataObfuscateString')]
+    public function testObfuscateString(mixed $input, int $margins, string $expected): void
     {
         $Strink = new Strink();
-        $this->assertEquals('my**********ng', $Strink->obfuscateString('mysecretstring', 2));
-        $this->assertEquals('myse******ring', $Strink->obfuscateString('mysecretstring', 4));
-        $this->assertEquals('short', $Strink->obfuscateString('short', 10));
-        $this->assertEquals('șa*pe', $Strink->obfuscateString('șarpe', 2));
+        $this->assertEquals($expected, $Strink->obfuscateString($input, $margins));
+    }
+
+    public static function dataObfuscateString(): array
+    {
+        return [
+            ['mysecretstring', 2, 'my**********ng'],
+            ['mysecretstring', 4, 'myse******ring'],
+            ['short', 10, 'short'],
+            ['șarpe', 2, 'șa*pe'],
+            [12345, 2, '12*45'],
+        ];
     }
 
     public function testLimitedString(): void


### PR DESCRIPTION
## Summary
- Cast obfuscateString input to string so non-string values are safely obfuscated
- Add data provider for obfuscateString tests including integer input

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c24f06a7888328aa7086afa316fae7