### PR TITLE
Define FormElement attribute for eCommerce traits

### DIFF
--- a/src/Attribute/FormElement.php
+++ b/src/Attribute/FormElement.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sindla\Bundle\AuroraBundle\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class FormElement
+{
+    public function __construct(
+        public bool $searchable = false,
+        public ?string $label = null,
+    ) {
+    }
+}

--- a/src/Entity/SuperAttribute/ECommerce/AmountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/AmountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/BankTransfer/BankTransferAmountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/BankTransfer/BankTransferAmountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce\BankTransfer;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/BankTransfer/BankTransferDiscountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/BankTransfer/BankTransferDiscountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce\BankTransfer;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/Card/CardAmountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/Card/CardAmountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce\Card;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/Card/CardDiscountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/Card/CardDiscountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce\Card;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/Cash/CashAmountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/Cash/CashAmountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce\Cash;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/Cash/CashDiscountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/Cash/CashDiscountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce\Cash;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/DiscountPerItemTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/DiscountPerItemTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/DiscountTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/DiscountTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/PricePerItemTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/PricePerItemTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;

--- a/src/Entity/SuperAttribute/ECommerce/PriceTrait.php
+++ b/src/Entity/SuperAttribute/ECommerce/PriceTrait.php
@@ -2,7 +2,7 @@
 
 namespace Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\ECommerce;
 
-use App\Attribute\FormElement;
+use Sindla\Bundle\AuroraBundle\Attribute\FormElement;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sindla\Bundle\AuroraBundle\Config\AuroraConstants;


### PR DESCRIPTION
## Summary
- introduce a FormElement attribute for reusable metadata
- reference the new attribute across eCommerce traits instead of the missing `App` namespace

## Testing
- `vendor/bin/phpstan analyse --memory-limit=2G` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c254ab638883289adc7a764755ce00