### PR TITLE
Fix case sensitivity in CSS URL matcher

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -38,9 +38,8 @@ class AuroraMatch
     public function matchCssUrls(string $css, bool $relativeUrlOnly = true): array
     {
         $pattern = $relativeUrlOnly
-            ? '/url\((?![\'"]?(?:data|https|http):)[\'"]?([^\'"\)]*)[\'"]?\)/'
-            : '/url\([\'"]?([^\'"\)]*)[\'"]?\)/';
-
+            ? '/url\((?![\'"]?(?:data|https|http):)[\'"]?([^\'"\)]*)[\'"]?\)/i'
+            : '/url\([\'"]?([^\'"\)]*)[\'"]?\)/i';
         preg_match_all($pattern, $css, $matches);
         return $matches;
     }

--- a/tests/Utils/AuroraMatch/AuroraMatchTest.php
+++ b/tests/Utils/AuroraMatch/AuroraMatchTest.php
@@ -264,4 +264,14 @@ body {
         $this->assertTrue($Match->passwordStrength('Te$1123321', true, true, true, true, 6));
         $this->assertFalse($Match->passwordStrength('Te$11233212214', true, true, true, true, 6, 9));
     }
+    public function testMatchCssUrlsIsCaseInsensitive(): void
+    {
+        $match = new AuroraMatch();
+
+        $cssRelative = "body { background: URL('/img/bg.png'); }";
+        $this->assertSame(['/img/bg.png'], $match->matchCssUrls($cssRelative)[1]);
+
+        $cssAbsolute = "body { background: URL('HTTP://example.com/bg.png'); }";
+        $this->assertSame([], $match->matchCssUrls($cssAbsolute)[1]);
+    }
 }


### PR DESCRIPTION
## Summary
- make `AuroraMatch::matchCssUrls` case-insensitive
- cover uppercase `URL()` and schemes in `AuroraMatchTest`

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraMatch/AuroraMatchTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c2575b51fc8328b6859fa04b778a02