### PR TITLE
Fix compressSpaces from removing newlines

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -26,7 +26,7 @@ class Strink
      */
     public function compressSpaces(): self
     {
-        $this->string = preg_replace('/\s\s+/', ' ', $this->string);
+        $this->string = preg_replace('/ {2,}/', ' ', $this->string);
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -109,8 +109,9 @@ class StrinkTest extends TestCase
     public function testCompressSpaces()
     {
         $this->assertEquals('Šîĝñ Îñ', new Strink()->string('Šîĝñ   Îñ')->compressSpaces());
-        $this->assertEquals('Šîĝñ Îñ', new Strink()->string("Šîĝñ \nÎñ")->compressSpaces());
+        $this->assertEquals("Šîĝñ \nÎñ", new Strink()->string("Šîĝñ \nÎñ")->compressSpaces());
         $this->assertEquals('Šîĝñ Îñ', new Strink()->string("Šîĝñ\x20\x20\x20Îñ")->compressSpaces());
+        $this->assertEquals("line1\n\nline2", new Strink()->string("line1\n\nline2")->compressSpaces());
         $this->assertEquals('Ora de început', new Strink()->string('Ora de          început')->compressSpaces());
     }
 


### PR DESCRIPTION
## Summary
- prevent `compressSpaces` from collapsing newlines
- expand tests covering newline handling in `compressSpaces`

## Testing
- `phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c26bc0b61483289925648916b084c2