### PR TITLE
Fix age filter to use start-of-year reference

### DIFF
--- a/src/Utils/Twig/UtilityExtension.php
+++ b/src/Utils/Twig/UtilityExtension.php
@@ -52,7 +52,7 @@ class UtilityExtension extends AbstractExtension
 
     public function filterAge(\DateTime $date): int
     {
-        $referenceDateTimeObject = new \DateTime();
+        $referenceDateTimeObject = new \DateTime(date('Y') . '-01-01');
 
         $diff = $referenceDateTimeObject->diff($date);
 

--- a/tests/Utils/Twig/UtilityExtensionTest.php
+++ b/tests/Utils/Twig/UtilityExtensionTest.php
@@ -1,45 +1,13 @@
 <?php declare(strict_types=1);
 
-namespace Twig\Extension;
-
-abstract class AbstractExtension {}
-
-namespace Twig;
-
-class Environment {}
-
-namespace Symfony\Component\DependencyInjection;
-
-class Container {}
-
-namespace Symfony\Component\HttpFoundation;
-
-class RequestStack {}
-
-namespace Sindla\Bundle\AuroraBundle\Utils\AuroraHelper;
-
-class AuroraHelper {}
-
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Twig;
 
-// PHPUnit
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraHelper\AuroraHelper;
 use Sindla\Bundle\AuroraBundle\Utils\Twig\UtilityExtension;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Twig\Environment;
-
-// Aurora
-use Sindla\Bundle\AuroraBundle\Utils\AuroraHelper\AuroraHelper;
-use Sindla\Bundle\AuroraBundle\Utils\Twig\UtilityExtension;
-
-// Symfony
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\HttpFoundation\RequestStack;
-
-// Twig
 use Twig\Environment;
 
 /**


### PR DESCRIPTION
## Summary
- ensure `UtilityExtension::filterAge` uses the first day of the current year for consistent age computation
- clean up `UtilityExtensionTest` to rely on real Symfony and Twig classes

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/Twig/UtilityExtensionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2b54bf42c8328bbdd366db5aa43d0