### PR TITLE
Avoid AuroraHelper alias conflicts in Twig UtilityExtension tests

### DIFF
--- a/tests/Utils/Twig/UtilityExtensionTest.php
+++ b/tests/Utils/Twig/UtilityExtensionTest.php
@@ -4,7 +4,7 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Twig;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Sindla\Bundle\AuroraBundle\Utils\AuroraHelper\AuroraHelper;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraHelper\AuroraHelper as AuroraHelperUtils;
 use Sindla\Bundle\AuroraBundle\Utils\Twig\UtilityExtension;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -34,7 +34,7 @@ class UtilityExtensionTest extends TestCase
             new Container(),
             new RequestStack(),
             $this->createStub(Environment::class),
-            new AuroraHelper()
+            new AuroraHelperUtils()
         );
 
         $this->assertSame($expected, $extension->filterAge($given));


### PR DESCRIPTION
## Summary
- Use distinct alias `AuroraHelperUtils` for helper import in `UtilityExtensionTest`

## Testing
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan not found)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Twig/UtilityExtensionTest.php` *(fails: Class `Twig\Extension\AbstractExtension` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b642778883289a259f4a3e493cea