### PR TITLE
Fix regex replacement in compressSlashes and add tests

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -44,7 +44,7 @@ class Strink
      */
     public function compressSlashes(): self
     {
-        $this->string = preg_replace('~(^|[^:])//+~', '\\1/', $this->string);
+        $this->string = preg_replace('~(^|[^:])//+~', '\1/', $this->string);
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -115,6 +115,13 @@ class StrinkTest extends TestCase
         $this->assertEquals('Ora de început', new Strink()->string('Ora de          început')->compressSpaces());
     }
 
+    public function testCompressSlashes(): void
+    {
+        $Strink = new Strink();
+        $this->assertEquals('http://example.com/foo/bar', $Strink->string('http://example.com//foo///bar')->compressSlashes());
+        $this->assertEquals('/foo/bar', $Strink->string('////foo//bar')->compressSlashes());
+    }
+
     public function testCompressDoubleQuotes(): void
     {
         $this->assertEquals("\"Pleașe țest thîs string\"", new Strink()->string("\"\"Pleașe țest thîs string\"\"")->compressDoubleQuotes());


### PR DESCRIPTION
## Summary
- ensure `compressSlashes` uses a proper regex backreference
- cover slash compression with a new unit test

## Testing
- `vendor/bin/phpstan analyse` *(fails: vendor/bin/phpstan: No such file or directory)*
- `composer create-project symfony/skeleton:7.3 temp_project --no-cache` *(fails: Could not find package symfony/skeleton with version 7.3)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/Strink/StrinkTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3c2a5cf208328b9733d2248fc5f31