### PR TITLE
Fix multibyte support in camelCaseToSnakeCase

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -235,7 +235,9 @@ class Strink
      */
     public function camelCaseToSnakeCase(): self
     {
-        $this->string = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $this->string));
+        $encoding     = $this->detectEncoding();
+        $this->string = preg_replace('/(?<!^)\p{Lu}/u', '_$0', $this->string);
+        $this->string = mb_strtolower($this->string, $encoding);
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -43,6 +43,9 @@ class StrinkTest extends TestCase
                 $this->assertEquals($expected, $Strink->string($given)->camelCaseToSnakeCase());
             }
         }
+
+        // UTF-8 support
+        $this->assertEquals('denumire_șarpe', $Strink->string('DenumireȘarpe')->camelCaseToSnakeCase());
     }
 
     public function testSnakeCaseToCamelCase(): void


### PR DESCRIPTION
## Summary
- handle Unicode uppercase characters in Strink::camelCaseToSnakeCase
- test camelCaseToSnakeCase with multibyte characters

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` (errors: 982)
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c3d894e97c83289e12f53f9d234e8d