### PR TITLE
Fix AuroraCryptor encryption output and add tests

### DIFF
--- a/src/Utils/AuroraCryptor/AuroraCryptor.php
+++ b/src/Utils/AuroraCryptor/AuroraCryptor.php
@@ -17,7 +17,6 @@ class AuroraCryptor
     public function __construct()
     {
         $this->randomInitializationVector = openssl_random_pseudo_bytes(openssl_cipher_iv_length($this->cipher));
-        return $this;
     }
 
     public function setCipher($cipher = 'AES-128-CTR'): self
@@ -39,7 +38,8 @@ class AuroraCryptor
     {
         $encrypted           = openssl_encrypt($data, $this->cipher, $this->encryptionKey, $this->options, $this->randomInitializationVector);
         $this->encryptionKey = null;
-        return "{$encrypted}::{$this->randomInitializationVector}";
+
+        return base64_encode($encrypted . '::' . $this->randomInitializationVector);
     }
 
     /**

--- a/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
+++ b/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCryptor;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraCryptor\AuroraCryptor;
+
+/**
+ * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraCryptor/AuroraCryptorTest.php --no-coverage
+ */
+class AuroraCryptorTest extends TestCase
+{
+    public function testEncryptAndDecrypt(): void
+    {
+        $cryptor = new AuroraCryptor();
+        $key = 'myPa$$worD123';
+        $data = 'megaSecretKey';
+
+        $encrypted = $cryptor->setEncryptionKey($key)->encrypt($data);
+        $decoded = base64_decode($encrypted, true);
+
+        $this->assertNotFalse($decoded);
+        $this->assertStringContainsString('::', $decoded);
+
+        $decrypted = $cryptor->setEncryptionKey($key)->decrypt($encrypted);
+        $this->assertSame($data, $decrypted);
+    }
+}


### PR DESCRIPTION
## Summary
- remove invalid return from AuroraCryptor constructor
- base64-encode encrypted payload and IV in AuroraCryptor
- cover AuroraCryptor encryption/decryption with a new PHPUnit test

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class "Symfony\Bundle\FrameworkBundle\Test\KernelTestCase" not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraCryptor/AuroraCryptorTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c3e7cf55a883288dd81e7d47bb879a