### PR TITLE
Fix age calculation in Twig utility

### DIFF
--- a/src/Utils/Twig/UtilityExtension.php
+++ b/src/Utils/Twig/UtilityExtension.php
@@ -52,7 +52,7 @@ class UtilityExtension extends AbstractExtension
 
     public function filterAge(\DateTime $date): int
     {
-        $referenceDateTimeObject = new \DateTime(date('Y') . '-01-01');
+        $referenceDateTimeObject = new \DateTime();
 
         $diff = $referenceDateTimeObject->diff($date);
 

--- a/tests/Utils/Twig/UtilityExtensionTest.php
+++ b/tests/Utils/Twig/UtilityExtensionTest.php
@@ -42,7 +42,7 @@ class UtilityExtensionTest extends TestCase
 
     public static function dataFilterAge(): array
     {
-        $reference = new \DateTime(date('Y') . '-01-01');
+        $reference = new \DateTime();
 
         $years = [];
         for ($i = 0; $i < 48; $i++) {


### PR DESCRIPTION
## Summary
- fix age calculation to use current date
- adjust age filter test data provider

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M src/Utils/Twig/UtilityExtension.php tests/Utils/Twig/UtilityExtensionTest.php`
- `vendor/bin/phpunit --no-coverage tests/Utils/Twig/UtilityExtensionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3f702c98c8328ae57ad5bfea3624f