### PR TITLE
Handle zero divisor in percentage change

### DIFF
--- a/src/Utils/Calculus/Calculus.php
+++ b/src/Utils/Calculus/Calculus.php
@@ -42,14 +42,14 @@ class Calculus
     }
 
     /**
-     * Return percentage between two numbers
-     *
-     * @param $newNumber
-     * @param $originalNumber
-     * @return float|int
+     * Return percentage between two numbers.
      */
-    public function percentageChange($newNumber, $originalNumber)
+    public function percentageChange(float $newNumber, float $originalNumber): float
     {
-        return ((($newNumber - $originalNumber) / $originalNumber) * 100);
+        if (0.0 === $originalNumber) {
+            return 0.0;
+        }
+
+        return (($newNumber - $originalNumber) / $originalNumber) * 100;
     }
 }

--- a/tests/Utils/Calculus/CalculusTest.php
+++ b/tests/Utils/Calculus/CalculusTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Calculus;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\Calculus\Calculus;
+
+class CalculusTest extends TestCase
+{
+    #[DataProvider('providePercentageChange')]
+    /**
+     * @dataProvider providePercentageChange
+     */
+    public function testPercentageChange(float $expected, float $new, float $original): void
+    {
+        $Calculus = new Calculus();
+        $this->assertSame($expected, $Calculus->percentageChange($new, $original));
+    }
+
+    public static function providePercentageChange(): array
+    {
+        return [
+            'increase' => [20.0, 120.0, 100.0],
+            'zero-original' => [0.0, 50.0, 0.0],
+            'both-zero' => [0.0, 0.0, 0.0],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- avoid division by zero in `Calculus::percentageChange`
- cover percentage change edge cases with new tests

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Class Symfony\Component\Dotenv\Dotenv not found)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: Class Symfony\Bundle\FrameworkBundle\Test\KernelTestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c420b30424832895413634f6599c75