### PR TITLE
Add APCu fallback for Git utilities and tests

### DIFF
--- a/src/Utils/Git/Git.php
+++ b/src/Utils/Git/Git.php
@@ -3,6 +3,8 @@
 namespace Sindla\Bundle\AuroraBundle\Utils\Git;
 
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -22,9 +24,20 @@ class Git
         $this->container = $Container;
     }
 
+    private function createCache(): AdapterInterface
+    {
+        $lifetime = ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1);
+
+        if (ApcuAdapter::isSupported()) {
+            return new ApcuAdapter('', $lifetime);
+        }
+
+        return new ArrayAdapter($lifetime);
+    }
+
     public function getBranch()
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCache();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__), function (ItemInterface $item) {
             $root = $this->container->getParameter('aurora.root');
@@ -46,7 +59,7 @@ class Git
 
     public function gitLatestTag(): ?string
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCache();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__), function (ItemInterface $item) {
 
@@ -74,7 +87,7 @@ class Git
 
     public function gitLatestTagHash(): ?string
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCache();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__), function (ItemInterface $item) {
 
@@ -102,7 +115,7 @@ class Git
 
     public function getHash(?string $branch = null)
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCache();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__), function (ItemInterface $item) use ($branch) {
             if (!$branch) {
@@ -132,7 +145,7 @@ class Git
 
     public function getDate(?string $branch = null): ?string
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCache();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__), function (ItemInterface $item) use ($branch) {
 
@@ -177,6 +190,6 @@ class Git
 
     public function getTag(): ?string
     {
-
+        return $this->gitLatestTag();
     }
 }

--- a/tests/Utils/Git/GitTest.php
+++ b/tests/Utils/Git/GitTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Git;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\Git\Git;
+use Symfony\Component\DependencyInjection\Container;
+
+class GitTest extends TestCase
+{
+    private function createContainer(string $root): Container
+    {
+        $container = new Container();
+        $container->setParameter('kernel.environment', 'dev');
+        $container->setParameter('aurora.root', $root);
+
+        return $container;
+    }
+
+    public function testGetTagReturnsLatestTag(): void
+    {
+        $root = sys_get_temp_dir() . '/aurora_git_' . uniqid();
+        mkdir($root . '/.git/refs/tags', 0777, true);
+        file_put_contents($root . '/.git/HEAD', "ref: refs/heads/main\n");
+        file_put_contents($root . '/.git/refs/tags/v1', 'hash1');
+        file_put_contents($root . '/.git/refs/tags/v2', 'hash2');
+
+        $git = new Git($this->createContainer($root));
+
+        $this->assertSame('v2', $git->getTag());
+        $this->assertSame('hash2', $git->gitLatestTagHash());
+    }
+
+    public function testFallbackWhenNotGitRepo(): void
+    {
+        $root = sys_get_temp_dir() . '/aurora_git_' . uniqid();
+        mkdir($root, 0777, true);
+
+        $git = new Git($this->createContainer($root));
+
+        $this->assertSame('NOT-A-GIT-REPO', $git->getBranch());
+        $this->assertNull($git->getTag());
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle missing APCu extension by falling back to ArrayAdapter in Git utils
- expose latest tag via new getTag() helper
- add unit tests for Git utility behavior

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `vendor/bin/phpunit --no-coverage --no-extensions -c phpunit.xml.dist tests/Utils/Git/GitTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c441db91808328b88d46d78502f260