### PR TITLE
Fix limitedString exceeding limit when post text is longer

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -158,6 +158,11 @@ class Strink
         $postTextLength = mb_strlen($postText, 'utf-8');
 
         if ($stringLength > $limit) {
+            if ($limit <= $postTextLength) {
+                $this->string = mb_substr($postText, 0, $limit, 'utf-8');
+                return $this;
+            }
+
             $limitedString = $this->string;
 
             if ($cut == 'right') {

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -238,6 +238,7 @@ class StrinkTest extends TestCase
         $this->assertEquals('Șîĝñ', (string) $Strink->string('Șîĝñ')->limitedString(4));
         $this->assertEquals('...', (string) $Strink->string('Șîĝñ')->limitedString(3));
         $this->assertEquals('Ș...', (string) $Strink->string('Șîĝñț')->limitedString(4));
+        $this->assertEquals('..', (string) $Strink->string('Șîĝñț')->limitedString(2));
     }
 
     ##########################################################################################################################################################################################


### PR DESCRIPTION
## Summary
- ensure `limitedString` truncates post text when limit is shorter
- cover `limitedString` with a test for short limits

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: 1424 errors)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c44533c120832881042b3d10219ae3