### PR TITLE
Handle consecutive underscores in snakeCaseToHumanCase

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -217,7 +217,9 @@ class Strink
         $encoding = $this->detectEncoding();
 
         $this->string = mb_strtolower($this->string, $encoding);
-        $this->string = str_replace('_', ' ', $this->string);
+        $this->string = preg_replace('/_+/', ' ', $this->string) ?? '';
+        $this->compressSpaces();
+        $this->string = trim($this->string);
 
         if ($upperCaseAllLetters) {
             $this->string = mb_convert_case($this->string, MB_CASE_TITLE, $encoding);

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -80,6 +80,18 @@ class StrinkTest extends TestCase
         $Strink = new Strink();
 
         foreach ([
+                     'external request repository' => [
+                         'external_request_repository',
+                         'external__request__repository',
+                         '__external_request__repository__'
+                     ]
+                 ] as $expected => $givens) {
+            foreach ($givens as $given) {
+                $this->assertEquals($expected, $Strink->string($given)->snakeCaseToHumanCase());
+            }
+        }
+
+        foreach ([
                      'External request repository' => ['external_request_repository']
                  ] as $expected => $givens) {
             foreach ($givens as $given) {


### PR DESCRIPTION
## Summary
- normalize repeated underscores in `snakeCaseToHumanCase`
- test snake-case to human-case conversion across multiple underscores

## Testing
- `vendor/bin/phpstan analyse` *(fails: syntax errors and memory limit)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c454a6f75c8328a796d6e18ef123b4