### PR TITLE
Validate subnet prefix length and test AuroraIP

### DIFF
--- a/src/Utils/AuroraIP/AuroraIP.php
+++ b/src/Utils/AuroraIP/AuroraIP.php
@@ -31,12 +31,12 @@ class AuroraIP
         return (bool)filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
     }
 
-    public function isIPInSubnet(string $ipv6, string $cidr): bool
+    public function isIPInSubnet(string $ip, string $cidr): bool
     {
         [$subnet, $prefixLength] = explode('/', $cidr);
-        $prefixLength = (int)$prefixLength;
+        $prefixLength = (int) $prefixLength;
 
-        $ipBin     = inet_pton($ipv6);
+        $ipBin     = inet_pton($ip);
         $subnetBin = inet_pton($subnet);
 
         if ($ipBin === false || $subnetBin === false || strlen($ipBin) !== strlen($subnetBin)) {
@@ -46,16 +46,20 @@ class AuroraIP
         // 32 for IPv4, 128 for IPv6
         $totalBits = strlen($ipBin) * 8;
 
-        $mask = str_repeat("\xff", (int)($prefixLength / 8));
+        if ($prefixLength < 0 || $prefixLength > $totalBits) {
+            return false;
+        }
+
+        $mask = str_repeat("\xff", (int) ($prefixLength / 8));
         $rest = $prefixLength % 8;
         if ($rest > 0) {
-            $mask .= chr(0xff << (8 - $rest) & 0xff);
+            $mask .= chr((0xff << (8 - $rest)) & 0xff);
         }
         $mask         = str_pad($mask, strlen($ipBin), "\0");
         $ipMasked     = $ipBin & $mask;
         $subnetMasked = $subnetBin & $mask;
 
-        return ($ipMasked === $subnetMasked);
+        return $ipMasked === $subnetMasked;
     }
 
     public function isPublicIPV6(string $ip): bool

--- a/tests/Utils/AuroraIP/AuroraIPTest.php
+++ b/tests/Utils/AuroraIP/AuroraIPTest.php
@@ -4,22 +4,14 @@ declare(strict_types=1);
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraIP;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraIP\AuroraIP;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
  * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraIP/AuroraIPTest.php --no-coverage
  */
-class AuroraIPTest extends KernelTestCase
+class AuroraIPTest extends TestCase
 {
-    private $kernelTest;
-    private $containerTest;
-
-    protected function setUp(): void
-    {
-        $this->kernelTest    = self::bootKernel();
-        $this->containerTest = $this->kernelTest->getContainer();
-    }
 
     public function testFake(): void
     {
@@ -74,4 +66,24 @@ class AuroraIPTest extends KernelTestCase
             ['999.999.999.999', false]
         ];
     }
-  }
+
+    /**
+     * @dataProvider dataIsIPInSubnet
+     */
+    #[DataProvider('dataIsIPInSubnet')]
+    public function testIsIPInSubnet(string $ip, string $cidr, bool $expected): void
+    {
+        $this->assertEquals($expected, (new AuroraIP())->isIPInSubnet($ip, $cidr));
+    }
+
+    public static function dataIsIPInSubnet(): array
+    {
+        return [
+            ['192.168.1.5', '192.168.1.0/24', true],
+            ['192.168.2.5', '192.168.1.0/24', false],
+            ['2001:db8::1', '2001:db8::/32', true],
+            ['2001:db9::1', '2001:db8::/32', false],
+            ['192.168.1.5', '192.168.1.0/33', false],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- validate CIDR prefix length before comparing IPs
- convert AuroraIP tests to plain PHPUnit and cover subnet matching

## Testing
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraIP/AuroraIPTest.php`
- `vendor/bin/phpstan analyse src/Utils/AuroraIP/AuroraIP.php --memory-limit=1G`


------
https://chatgpt.com/codex/tasks/task_e_68c52264be0c8328a58c5c32cc9165b7