### PR TITLE
Handle negative hash lengths

### DIFF
--- a/src/Utils/Twig/UtilityExtension.php
+++ b/src/Utils/Twig/UtilityExtension.php
@@ -239,9 +239,9 @@ class UtilityExtension extends AbstractExtension
         return $serviceGit->gitLatestTagHash();
     }
 
-    public function getHash($size = 24): string
+    public function getHash(int $size = 24): string
     {
-        $size = min($size, 40);
+        $size = max(0, min($size, 40));
 
         return substr(sha1(microtime() . time() . uniqid()), 0, $size);
     }

--- a/tests/Utils/Twig/UtilityExtensionTest.php
+++ b/tests/Utils/Twig/UtilityExtensionTest.php
@@ -66,4 +66,32 @@ class UtilityExtensionTest extends TestCase
 
         return $data;
     }
+
+    /**
+     * @dataProvider dataGetHash
+     */
+    #[DataProvider('dataGetHash')]
+    public function testGetHash(int $size, int $expectedLength): void
+    {
+        $extension = new UtilityExtension(
+            new Container(),
+            new RequestStack(),
+            $this->createStub(Environment::class),
+            new AuroraHelperUtils()
+        );
+
+        $hash = $extension->getHash($size);
+
+        $this->assertSame($expectedLength, strlen($hash));
+    }
+
+    public static function dataGetHash(): array
+    {
+        return [
+            [5, 5],
+            [50, 40],
+            [0, 0],
+            [-5, 0],
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- ensure Twig UtilityExtension handles non-positive hash sizes safely
- cover UtilityExtension::getHash edge cases with tests

## Testing
- `vendor/bin/phpstan analyse src/Utils/Twig/UtilityExtension.php tests/Utils/Twig/UtilityExtensionTest.php --memory-limit=512M`
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/Twig/UtilityExtensionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c527090c1c8328af487133b6b70291