### PR TITLE
Fix IO recursive delete to remove hidden files

### DIFF
--- a/src/Utils/IO/IO.php
+++ b/src/Utils/IO/IO.php
@@ -31,26 +31,26 @@ class IO
      */
     public function recursiveDelete(string $str, bool $removeGivenDir = true): bool
     {
-        if (is_file($str)) {
+        if (is_file($str) || is_link($str)) {
             return @unlink($str);
+        }
 
-        } else if (is_dir($str)) {
-            $scan = glob(rtrim($str, '/') . '/*');
-
-            if (is_array($scan) && count($scan) > 0) {
-                foreach ($scan as $index => $path) {
-                    $this->recursiveDelete($path);
+        if (is_dir($str)) {
+            $items = @scandir($str);
+            if (is_array($items)) {
+                foreach (array_diff($items, ['.', '..']) as $item) {
+                    $this->recursiveDelete($str . '/' . $item);
                 }
             }
 
-            if ($removeGivenDir === true) {
+            if ($removeGivenDir) {
                 return @rmdir($str);
-            } else {
-                return true;
             }
-        } else {
-            return false;
+
+            return true;
         }
+
+        return false;
     }
 
     public function dirIsEmpty(string $directory): bool

--- a/tests/Utils/IO/IOTest.php
+++ b/tests/Utils/IO/IOTest.php
@@ -4,25 +4,13 @@ declare(strict_types=1);
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\IO;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\HttpClient\HttpClient;
 use Sindla\Bundle\AuroraBundle\Utils\IO\IO;
 
 /**
  * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/IO/IOTest.php --no-coverage
  */
-class IOTest extends KernelTestCase
+class IOTest extends TestCase
 {
-    private $kernelTest;
-    private $containerTest;
-
-    protected function setUp(): void
-    {
-        $this->kernelTest    = self::bootKernel();
-        $this->containerTest = $this->kernelTest->getContainer();
-    }
-
     public function testFake(): void
     {
         $this->assertTrue(true);
@@ -31,15 +19,37 @@ class IOTest extends KernelTestCase
 
     public function testFileIsOlderThan(): void
     {
-        /** @var  $IO */
         $IO = new IO();
 
-        // Temporary file
         $tmpFile = tempnam(sys_get_temp_dir(), 'aurora');
 
         $this->assertFalse($IO->fileIsOlderThan($tmpFile, 1, IO::TIME_UNIT_MINUTES));
         sleep(3);
         $this->assertTrue($IO->fileIsOlderThan($tmpFile, 1, IO::TIME_UNIT_SECONDS));
         unlink($tmpFile);
+    }
+
+    public function testRecursiveDeleteHandlesHiddenFiles(): void
+    {
+        $IO  = new IO();
+        $dir = sys_get_temp_dir() . '/aurora_' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/visible.txt', 'visible');
+        file_put_contents($dir . '/.hidden', 'hidden');
+
+        $this->assertTrue($IO->recursiveDelete($dir));
+        $this->assertDirectoryDoesNotExist($dir);
+    }
+
+    public function testRecursiveDeleteKeepsDirectoryWhenFlagFalse(): void
+    {
+        $IO  = new IO();
+        $dir = sys_get_temp_dir() . '/aurora_' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/file.txt', 'content');
+
+        $this->assertTrue($IO->recursiveDelete($dir, false));
+        $this->assertDirectoryExists($dir);
+        rmdir($dir);
     }
 }


### PR DESCRIPTION
## Summary
- ensure recursiveDelete handles hidden files and symbolic links
- cover recursiveDelete edge cases with new unit tests

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: class not found errors)*
- `vendor/bin/phpunit --no-coverage tests/Utils/IO/IOTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c528aaa7bc8328bf55a2886727f3fd