### PR TITLE
Fix missing V characters in Strink random generator

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -101,10 +101,10 @@ class Strink
 
         if (is_array($keysToUse) && count($keysToUse) == 0) {
             $keysToUse = [
-                'abcdefghijklmnopqrstuwxyz',
-                'ABCDEFGHIJKLMNOPQRSTUWXYZ',
+                'abcdefghijklmnopqrstuvwxyz',
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
                 '0123456789',
-                '!@#$%^&*+=' 
+                '!@#$%^&*+='
             ];
         }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -328,5 +328,13 @@ class StrinkTest extends TestCase
         $this->assertSame('', (string) $Strink->randomString(0));
     }
 
+    public function testRandomStringIncludesVCharacters(): void
+    {
+        mt_srand(0);
+        $result = (string) (new Strink())->randomString(1000);
+        $this->assertStringContainsString('v', $result);
+        $this->assertStringContainsString('V', $result);
+    }
+
     ##########################################################################################################################################################################################
 }


### PR DESCRIPTION
## Summary
- ensure Strink's randomString includes lowercase and uppercase V
- add test covering V generation when seed set

## Testing
- `vendor/bin/phpstan analyse src/Utils/Strink/Strink.php` *(fails: Property Sindla\Bundle\AuroraBundle\Utils\Strink\Strink::$string (string) does not accept string|null; ...)*
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c593387ebc8328935adf75851f080a