### PR TITLE
Remove duplicate nonce attribute from compressJs

### DIFF
--- a/src/Utils/Twig/UtilityExtension.php
+++ b/src/Utils/Twig/UtilityExtension.php
@@ -344,7 +344,7 @@ class UtilityExtension extends AbstractExtension
                     if (!preg_match('/http:|https:/', $asset)) {
                         $asset = $asset . '?v=' . (('dev' === $this->container->getParameter('kernel.environment')) ? uniqid() : $serviceGit->getHash());
                     }
-                    echo "\n\t" . '<script src="' . $asset . '" nonce="' . $this->getNonce() . '" nonce="' . $this->getNonce() . '"></script>';
+                    echo "\n\t" . '<script src="' . $asset . '" nonce="' . $this->getNonce() . '"></script>';
                 }
             }
         } else {

--- a/tests/Utils/Twig/UtilityExtensionTest.php
+++ b/tests/Utils/Twig/UtilityExtensionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraHelper\AuroraHelper as AuroraHelperUtils;
 use Sindla\Bundle\AuroraBundle\Utils\Twig\UtilityExtension;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 
@@ -93,5 +94,32 @@ class UtilityExtensionTest extends TestCase
             [0, 0],
             [-5, 0],
         ];
+    }
+
+    public function testCompressJsOutputsSingleNonce(): void
+    {
+        $container = new Container();
+        $container->setParameter('kernel.environment', 'prod');
+        $container->set('aurora.git', new class {
+            public function getHash(): string
+            {
+                return 'hash';
+            }
+        });
+
+        $extension = new UtilityExtension(
+            $container,
+            new RequestStack(),
+            $this->createStub(Environment::class),
+            new AuroraHelperUtils()
+        );
+
+        $request = new \Symfony\Component\HttpFoundation\Request();
+
+        ob_start();
+        $extension->compressJs($request, false, false, 'file.js');
+        $output = ob_get_clean();
+
+        $this->assertSame(1, substr_count($output, 'nonce='));
     }
 }


### PR DESCRIPTION
## Summary
- fix duplicate nonce attribute in UtilityExtension::compressJs
- cover UtilityExtension::compressJs with test ensuring single nonce

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M` (fails: Class Symfony\Component\Dotenv\Dotenv not found)
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/Twig/UtilityExtensionTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c59d375a0c83289cf60d6b58be2dca