### PR TITLE
Fix obfuscateString zero-margin behavior

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -138,7 +138,15 @@ class Strink
         $string = (string) $string;
         $length = mb_strlen($string, 'UTF-8');
 
-        if ($margins <= 0 || $length <= $margins * 2) {
+        if ($margins < 0) {
+            return $string;
+        }
+
+        if ($margins === 0) {
+            return str_repeat('*', $length);
+        }
+
+        if ($length <= $margins * 2) {
             return $string;
         }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -229,6 +229,7 @@ class StrinkTest extends TestCase
             ['short', 10, 'short'],
             ['șarpe', 2, 'șa*pe'],
             [12345, 2, '12*45'],
+            ['secret', 0, '******'],
         ];
     }
 


### PR DESCRIPTION
## Summary
- handle zero-margin case in `Strink::obfuscateString`
- cover zero-margin case with new test

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5a3fa59808328935e43a3c588bbdf