### PR TITLE
Handle empty key groups in random string generator

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -104,8 +104,18 @@ class Strink
                 'abcdefghijklmnopqrstuvwxyz',
                 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
                 '0123456789',
-                '!@#$%^&*+='
+                '!@#$%^&*+=',
             ];
+        }
+
+        $keysToUse = array_values(array_filter(
+            $keysToUse,
+            static fn ($key): bool => is_string($key) && $key !== ''
+        ));
+
+        if (count($keysToUse) === 0) {
+            $this->string = '';
+            return $this;
         }
 
         $password = '';

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -337,5 +337,13 @@ class StrinkTest extends TestCase
         $this->assertStringContainsString('V', $result);
     }
 
+    public function testRandomStringSkipsEmptyKeys(): void
+    {
+        mt_srand(1);
+        $result = (string) (new Strink())->randomString(5, ['abc', '']);
+        $this->assertSame(5, strlen($result));
+        $this->assertMatchesRegularExpression('/^[abc]+$/', $result);
+    }
+
     ##########################################################################################################################################################################################
 }


### PR DESCRIPTION
## Summary
- Avoid ValueError in Strink::randomString by ignoring empty key groups
- Test Strink::randomString to ensure empty key groups are skipped

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpstan analyse --memory-limit=512M`
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/Strink/StrinkTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c5b11e3acc83288f20bbb648c4d4e0