### PR TITLE
Use GitHub Actions junit.xml for PHPUnit badge

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -166,3 +166,9 @@ jobs:
 
             -   name: "Test RequirementsTest"
                 run: /usr/bin/php ${{ env.BUILD_DIR }}/vendor/bin/phpunit ${{ env.PHPUNIT_FLAGS }} -c ${{ env.BUILD_DIR }}/phpunit.xml.dist ${{ env.BUILD_DIR }}/vendor/sindla/aurora/tests/RequirementsTest.php
+
+            -   name: "Generate PHPUnit badges"
+                working-directory: ${{ env.BUILD_DIR }}
+                run: |
+                    /usr/bin/php vendor/bin/phpunit ${{ env.PHPUNIT_FLAGS }} --log-junit junit.xml -c phpunit.xml.dist vendor/sindla/aurora/tests/
+                    /usr/bin/php bin/console aurora:php-unit --action=generatePHPUnitPassingBadge --junitXMLFilePath=junit.xml --outputPassingSVGFilePath=vendor/sindla/aurora/.github/badges/phpunit.svg


### PR DESCRIPTION
## Summary
- Run PHPUnit once to create junit.xml
- Generate badges using junit.xml from GitHub Actions

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache`
- `vendor/bin/phpstan analyse` *(fails: Allowed memory size exhausted)*
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist` *(fails: KernelTestCase class not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c695f1edc083288cfe28fff1e0a734