### PR TITLE
Fix AuroraCryptor IV reuse vulnerability

### DIFF
--- a/src/Utils/AuroraCryptor/AuroraCryptor.php
+++ b/src/Utils/AuroraCryptor/AuroraCryptor.php
@@ -12,12 +12,6 @@ class AuroraCryptor
     private string $cipher  = 'AES-128-CTR';
     private        $encryptionKey;
     private        $options = 0;
-    private string $randomInitializationVector;
-
-    public function __construct()
-    {
-        $this->randomInitializationVector = openssl_random_pseudo_bytes(openssl_cipher_iv_length($this->cipher));
-    }
 
     public function setCipher($cipher = 'AES-128-CTR'): self
     {
@@ -36,10 +30,11 @@ class AuroraCryptor
      */
     public function encrypt(string $data): string
     {
-        $encrypted           = openssl_encrypt($data, $this->cipher, $this->encryptionKey, $this->options, $this->randomInitializationVector);
+        $vector              = openssl_random_pseudo_bytes(openssl_cipher_iv_length($this->cipher));
+        $encrypted           = openssl_encrypt($data, $this->cipher, $this->encryptionKey, $this->options, $vector);
         $this->encryptionKey = null;
 
-        return base64_encode($encrypted . '::' . $this->randomInitializationVector);
+        return base64_encode($encrypted . '::' . $vector);
     }
 
     /**

--- a/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
+++ b/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
@@ -26,4 +26,16 @@ class AuroraCryptorTest extends TestCase
         $decrypted = $cryptor->setEncryptionKey($key)->decrypt($encrypted);
         $this->assertSame($data, $decrypted);
     }
+
+    public function testEncryptUsesUniqueInitializationVector(): void
+    {
+        $cryptor = new AuroraCryptor();
+        $key    = 'myPa$$worD123';
+        $data   = 'megaSecretKey';
+
+        $first  = $cryptor->setEncryptionKey($key)->encrypt($data);
+        $second = $cryptor->setEncryptionKey($key)->encrypt($data);
+
+        $this->assertNotSame($first, $second);
+    }
 }


### PR DESCRIPTION
## Summary
- generate a fresh initialization vector for each AuroraCryptor encryption
- test that encryption reuses unique IVs

## Testing
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraCryptor/AuroraCryptorTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c71c779d9883289898bf0ac9964397