### PR TITLE
Guard test Request stub to fix coverage run

### DIFF
--- a/tests/Utils/AuroraClient/AuroraClientBotTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientBotTest.php
@@ -3,23 +3,25 @@
 declare(strict_types=1);
 
 namespace Symfony\Component\HttpFoundation {
-    class Request
-    {
-        public function __construct(
-            array $query = [],
-            array $request = [],
-            array $attributes = [],
-            array $cookies = [],
-            array $files = [],
-            array $server = [],
-            $content = null
-        ) {
-            $this->server = $server;
-        }
-
-        public function getClientIp(): ?string
+    if (!class_exists(Request::class)) {
+        class Request
         {
-            return $this->server['REMOTE_ADDR'] ?? null;
+            public function __construct(
+                array $query = [],
+                array $request = [],
+                array $attributes = [],
+                array $cookies = [],
+                array $files = [],
+                array $server = [],
+                $content = null
+            ) {
+                $this->server = $server;
+            }
+
+            public function getClientIp(): ?string
+            {
+                return $this->server['REMOTE_ADDR'] ?? null;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid redefining Symfony Request in tests when framework is present

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `/usr/bin/phpunit -c phpunit.xml.dist tests/Controller/BlackHoleControllerTest.php` *(fails: Composer requires PHP >=8.4.0, 8.3.6 used)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b191b56c832885ccf101bf856799