### PR TITLE
Fix PHPUnit coverage source paths

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -57,9 +57,12 @@
     <source>
         <include>
             <directory suffix=".php">src</directory>
+            <directory suffix=".php">vendor/sindla/aurora/src</directory>
         </include>
         <exclude>
             <directory suffix=".php">src/Migrations</directory>
+            <directory suffix=".php">vendor/sindla/aurora/src/Migrations</directory>
+            <file>src/Kernel.php</file>
         </exclude>
     </source>
 


### PR DESCRIPTION
## Summary
- add the vendor copy of the Aurora bundle to PHPUnit's included source paths so coverage runs in the GH workflow record bundle files
- exclude the Symfony skeleton's Kernel and vendor migrations from the coverage report to avoid skewing badge values

## Testing
- php vendor/bin/phpunit --coverage-clover .github/.test-results/clover.xml -c phpunit.xml.dist vendor/sindla/aurora/tests/ *(fails: No code coverage driver available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e655da1483289616762a675fc945