### PR TITLE
Allow whitespace when matching CSS URLs

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -40,12 +40,16 @@ class AuroraMatch
     public function matchCssUrls(string $css, bool $relativeUrlOnly = true): array
     {
         if ($relativeUrlOnly) {
-            $pattern = '/url\((?![\'\"]?(?:data:|https?:|\/\/))[\'\"]?([^\'\"\)]*)[\'\"]?\)/i';
+            $pattern = '/url\(\s*(?!\s*[\'\"]?(?:data:|https?:|\/\/))\s*[\'\"]?([^\'\"\)]*)[\'\"]?\s*\)/i';
         } else {
-            $pattern = '/url\([\'\"]?([^\'\"\)]*)[\'\"]?\)/i';
+            $pattern = '/url\(\s*[\'\"]?([^\'\"\)]*)[\'\"]?\s*\)/i';
         }
 
         preg_match_all($pattern, $css, $matches);
+
+        if (!empty($matches[1])) {
+            $matches[1] = array_map(static fn(string $url): string => trim($url), $matches[1]);
+        }
 
         return $matches;
     }


### PR DESCRIPTION
## Summary
- allow optional whitespace in the CSS URL matching patterns
- trim extracted URL matches to avoid leading/trailing whitespace

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraMatch/AuroraMatchTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cab6c7a12883288be0a856e6180088