### PR TITLE
Fix Sanitizer test container interface compatibility

### DIFF
--- a/tests/Utils/Sanitizer/SanitizerTest.php
+++ b/tests/Utils/Sanitizer/SanitizerTest.php
@@ -4,7 +4,10 @@ namespace Symfony\Component\DependencyInjection {
     if (!interface_exists(ContainerInterface::class)) {
         interface ContainerInterface
         {
-            public function get(string $id);
+            public const EXCEPTION_ON_INVALID_REFERENCE = 1;
+
+            public function get(string $id, int $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE): ?object;
+
             public function has(string $id): bool;
         }
     }
@@ -13,14 +16,18 @@ namespace Symfony\Component\DependencyInjection {
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Sanitizer {
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Sindla\Bundle\AuroraBundle\Utils\Sanitizer\Sanitizer;
 
 class SanitizerTest extends TestCase
 {
     public function testHtmlMinifyUsesJsMinifier(): void
     {
-        $container = new class implements \Symfony\Component\DependencyInjection\ContainerInterface {
-            public function get(string $id) {}
+        $container = new class implements ContainerInterface {
+            public function get(string $id, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE): ?object
+            {
+                return null;
+            }
             public function has(string $id): bool { return false; }
         };
 


### PR DESCRIPTION
## Summary
- align the fallback `ContainerInterface` stub used by `SanitizerTest` with Symfony's signature and exposed constant
- adjust the anonymous container implementation in the test to honour the new signature and import the interface for clarity

## Testing
- composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-zend-opcache
- vendor/bin/phpstan analyse *(fails: vendor/bin/phpstan missing)*
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist *(fails: vendor/bin/phpunit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68caeef38fc08328ab6f2d73e0148b2f