### PR TITLE
Fix build hash truncation limit

### DIFF
--- a/src/Utils/Twig/UtilityExtension.php
+++ b/src/Utils/Twig/UtilityExtension.php
@@ -218,7 +218,18 @@ class UtilityExtension extends AbstractExtension
     {
         $serviceGit = $this->container->get('aurora.git');
         $build      = $serviceGit->getHash();
-        return substr($build, 0, ($limit ? $limit : strlen($build)));
+
+        if (null === $limit) {
+            return $build;
+        }
+
+        $limit = (int) $limit;
+
+        if ($limit <= 0) {
+            return '';
+        }
+
+        return substr($build, 0, $limit);
     }
 
     public function getBuildDate()

--- a/tests/Utils/Twig/UtilityExtensionTest.php
+++ b/tests/Utils/Twig/UtilityExtensionTest.php
@@ -69,6 +69,28 @@ class UtilityExtensionTest extends TestCase
     }
 
     /**
+     * @dataProvider dataGetBuild
+     */
+    #[DataProvider('dataGetBuild')]
+    public function testGetBuild(?int $limit, string $expected): void
+    {
+        $extension = $this->createUtilityExtensionWithGitHash('abcdef');
+
+        $this->assertSame($expected, $extension->getBuild($limit));
+    }
+
+    public static function dataGetBuild(): array
+    {
+        return [
+            'null limit returns full hash'      => [null, 'abcdef'],
+            'zero limit returns empty string'   => [0, ''],
+            'positive limit truncates hash'     => [3, 'abc'],
+            'longer limit keeps full hash'      => [10, 'abcdef'],
+            'negative limit returns empty hash' => [-5, ''],
+        ];
+    }
+
+    /**
      * @dataProvider dataGetHash
      */
     #[DataProvider('dataGetHash')]
@@ -121,5 +143,27 @@ class UtilityExtensionTest extends TestCase
         $output = ob_get_clean();
 
         $this->assertSame(1, substr_count($output, 'nonce='));
+    }
+
+    private function createUtilityExtensionWithGitHash(string $hash): UtilityExtension
+    {
+        $container = new Container();
+        $container->set('aurora.git', new class($hash) {
+            public function __construct(private string $hash)
+            {
+            }
+
+            public function getHash(): string
+            {
+                return $this->hash;
+            }
+        });
+
+        return new UtilityExtension(
+            $container,
+            new RequestStack(),
+            $this->createStub(Environment::class),
+            new AuroraHelperUtils()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- ensure `UtilityExtension::getBuild()` honours zero and negative limits while leaving null to return the full hash
- add data-driven unit tests covering `getBuild()` truncation scenarios

## Testing
- `vendor/bin/phpunit --no-coverage tests/Utils/Twig/UtilityExtensionTest.php`
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: numerous existing project baseline issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9547123483288a640aa7bc94999c