### PR TITLE
Fix Cloudflare R2 endpoint parsing and add coverage

### DIFF
--- a/src/Utils/CloudflareR2/CloudflareR2.php
+++ b/src/Utils/CloudflareR2/CloudflareR2.php
@@ -8,23 +8,25 @@ use Aws\S3\S3Client;
 readonly class CloudflareR2
 {
     /**
-     * @throws \Exception
+     * @throws \RuntimeException
      */
     public function getEndpoint(): string
     {
         $this->checkCredentials();
-        preg_match('#^(.*)/([^/]+)$#', $_ENV['CLOUDFLARE_R2_API_ENDPOINT'], $matches);
-        return $matches[1];
+        [$endpoint] = $this->splitEndpointAndBucket();
+
+        return $endpoint;
     }
 
     /**
-     * @throws \Exception
+     * @throws \RuntimeException
      */
     public function getBucket(): string
     {
         $this->checkCredentials();
-        preg_match('#^(.*)/([^/]+)$#', $_ENV['CLOUDFLARE_R2_API_ENDPOINT'], $matches);
-        return $matches[2];
+        [, $bucket] = $this->splitEndpointAndBucket();
+
+        return $bucket;
     }
 
     /**
@@ -46,20 +48,62 @@ readonly class CloudflareR2
 
     private function checkCredentials(): void
     {
-        if (!isset($_ENV['CLOUDFLARE_R2_API_ENDPOINT'])) {
+        $endpoint  = $_ENV['CLOUDFLARE_R2_API_ENDPOINT'] ?? null;
+        $accessKey = $_ENV['CLOUDFLARE_R2_API_ACCESS_KEY_ID'] ?? null;
+        $secretKey = $_ENV['CLOUDFLARE_R2_API_SECRET_ACCESS_KEY'] ?? null;
+
+        if ($endpoint === null) {
             throw new \Exception('CLOUDFLARE_R2_API_ENDPOINT is not set');
-        } else if (!isset($_ENV['CLOUDFLARE_R2_API_ACCESS_KEY_ID'])) {
+        }
+
+        if ($accessKey === null) {
             throw new \Exception('CLOUDFLARE_R2_API_ACCESS_KEY_ID is not set');
-        } else if (!isset($_ENV['CLOUDFLARE_R2_API_SECRET_ACCESS_KEY'])) {
+        }
+
+        if ($secretKey === null) {
             throw new \Exception('CLOUDFLARE_R2_API_SECRET_ACCESS_KEY is not set');
         }
 
-        if (isset($_ENV['CLOUDFLARE_R2_API_ENDPOINT']) && !str_starts_with($_ENV['CLOUDFLARE_R2_API_ENDPOINT'], 'https://')) {
+        if (!str_starts_with($endpoint, 'https://')) {
             throw new \Exception('CLOUDFLARE_R2_API_ENDPOINT must start with https://');
-        } else if (isset($_ENV['CLOUDFLARE_R2_API_ACCESS_KEY_ID']) && empty($_ENV['CLOUDFLARE_R2_API_ACCESS_KEY_ID'])) {
+        }
+
+        if ($accessKey === '') {
             throw new \Exception('CLOUDFLARE_R2_API_ACCESS_KEY_ID is empty');
-        } else if (isset($_ENV['CLOUDFLARE_R2_API_SECRET_ACCESS_KEY']) && empty($_ENV['CLOUDFLARE_R2_API_SECRET_ACCESS_KEY'])) {
+        }
+
+        if ($secretKey === '') {
             throw new \Exception('CLOUDFLARE_R2_API_SECRET_ACCESS_KEY is empty');
         }
+    }
+
+    /**
+     * @return array{string, string}
+     *
+     * @throws \RuntimeException
+     */
+    private function splitEndpointAndBucket(): array
+    {
+        $endpoint = rtrim($_ENV['CLOUDFLARE_R2_API_ENDPOINT'], '/');
+        $parsedEndpoint = parse_url($endpoint);
+
+        if ($parsedEndpoint === false || !isset($parsedEndpoint['scheme'], $parsedEndpoint['host'])) {
+            throw new \RuntimeException('CLOUDFLARE_R2_API_ENDPOINT must be a valid URL.');
+        }
+
+        $path = $parsedEndpoint['path'] ?? '';
+        $bucket = ltrim($path, '/');
+
+        if ($bucket === '') {
+            throw new \RuntimeException('CLOUDFLARE_R2_API_ENDPOINT must include a non-empty bucket name.');
+        }
+
+        $baseEndpoint = $parsedEndpoint['scheme'] . '://' . $parsedEndpoint['host'];
+
+        if (isset($parsedEndpoint['port'])) {
+            $baseEndpoint .= ':' . $parsedEndpoint['port'];
+        }
+
+        return [$baseEndpoint, $bucket];
     }
 }

--- a/tests/Utils/CloudflareR2/CloudflareR2Test.php
+++ b/tests/Utils/CloudflareR2/CloudflareR2Test.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\CloudflareR2;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\CloudflareR2\CloudflareR2;
+
+class CloudflareR2Test extends TestCase
+{
+    /**
+     * @var array<string, string|null>
+     */
+    private array $originalEnv;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalEnv = [
+            'CLOUDFLARE_R2_API_ENDPOINT'          => $_ENV['CLOUDFLARE_R2_API_ENDPOINT'] ?? null,
+            'CLOUDFLARE_R2_API_ACCESS_KEY_ID'     => $_ENV['CLOUDFLARE_R2_API_ACCESS_KEY_ID'] ?? null,
+            'CLOUDFLARE_R2_API_SECRET_ACCESS_KEY' => $_ENV['CLOUDFLARE_R2_API_SECRET_ACCESS_KEY'] ?? null,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $key => $value) {
+            if ($value === null) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $value;
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testGetEndpointAndBucketReturnsSplitValues(): void
+    {
+        $this->seedEnv('https://example.r2.cloudflarestorage.com/my-bucket');
+
+        $cloudflare = new CloudflareR2();
+
+        self::assertSame('https://example.r2.cloudflarestorage.com', $cloudflare->getEndpoint());
+        self::assertSame('my-bucket', $cloudflare->getBucket());
+    }
+
+    public function testTrailingSlashIsIgnoredWhenSplittingEndpoint(): void
+    {
+        $this->seedEnv('https://example.r2.cloudflarestorage.com/my-bucket/');
+
+        $cloudflare = new CloudflareR2();
+
+        self::assertSame('https://example.r2.cloudflarestorage.com', $cloudflare->getEndpoint());
+        self::assertSame('my-bucket', $cloudflare->getBucket());
+    }
+
+    public function testExceptionIsThrownWhenBucketSegmentIsMissing(): void
+    {
+        $this->seedEnv('https://example.r2.cloudflarestorage.com');
+
+        $cloudflare = new CloudflareR2();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('bucket name');
+
+        $cloudflare->getEndpoint();
+    }
+
+    private function seedEnv(string $endpoint): void
+    {
+        $_ENV['CLOUDFLARE_R2_API_ENDPOINT']          = $endpoint;
+        $_ENV['CLOUDFLARE_R2_API_ACCESS_KEY_ID']     = 'access-key';
+        $_ENV['CLOUDFLARE_R2_API_SECRET_ACCESS_KEY'] = 'secret-key';
+    }
+}


### PR DESCRIPTION
## Summary
- harden Cloudflare R2 endpoint parsing to validate URL structure and require a bucket segment
- tighten credential checks to avoid undefined index notices
- add PHPUnit coverage for Cloudflare R2 endpoint splitting edge cases

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/CloudflareR2/CloudflareR2Test.php
- vendor/bin/phpstan analyse src/Utils/CloudflareR2/CloudflareR2.php tests/Utils/CloudflareR2/CloudflareR2Test.php --memory-limit=1G

------
https://chatgpt.com/codex/tasks/task_e_68cba9e88fc48328b598a74acc75ad09