### PR TITLE
Fix date conversion bug and add coverage

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -43,8 +43,18 @@ class AuroraChronos
      */
     public function dateToMachineDate(string $datetime, string $humanFormat): string
     {
-        $parsedDate = date_parse_from_format($humanFormat, $datetime);
-        return $parsedDate['year'] . '-' . str_pad($parsedDate['month'], 2, 0, STR_PAD_LEFT) . '-' . str_pad($parsedDate['day'], 2, 0, STR_PAD_LEFT);
+        $date = \DateTime::createFromFormat('!' . $humanFormat, $datetime);
+
+        if (!$date) {
+            return date('Y-m-d', strtotime($datetime));
+        }
+
+        $errors = \DateTime::getLastErrors();
+        if (($errors['error_count'] ?? 0) > 0) {
+            return date('Y-m-d', strtotime($datetime));
+        }
+
+        return $date->format('Y-m-d');
     }
 
     /**

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraChronos;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraChronos\AuroraChronos;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
  * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraChronos/AuroraChronosTest.php --no-coverage
  */
-class AuroraChronosTest extends KernelTestCase
+class AuroraChronosTest extends TestCase
 {
     /**
      * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraChronos/AuroraChronosTest.php --no-coverage --filter testMinutesBetweenTwoDates
@@ -162,6 +162,24 @@ class AuroraChronosTest extends KernelTestCase
                  ] as $test) {
             $this->assertEquals($test['expected'], $Chronos->dateToHuman($test['date'], $test['humanFormat']), json_encode($test));
         }
+    }
+
+    #[DataProvider('dataDateToMachineDate')]
+    /** @dataProvider dataDateToMachineDate */
+    public function testDateToMachineDate(string $expected, array $given): void
+    {
+        $this->assertSame(
+            $expected,
+            (new AuroraChronos())->dateToMachineDate($given[0], $given[1])
+        );
+    }
+
+    public static function dataDateToMachineDate(): array
+    {
+        return [
+            ['2013-09-28', ['28.09.2013', 'd.m.Y']],
+            ['2020-03-02', ['31.02.2020', 'd.m.Y']],
+        ];
     }
 
     #[DataProvider('dataDateToMachineDateTime')]


### PR DESCRIPTION
## Summary
- update `AuroraChronos::dateToMachineDate()` to rely on `DateTime::createFromFormat()` so invalid dates are normalised instead of producing impossible strings
- convert the AuroraChronos test case to `PHPUnit\Framework\TestCase` and add focused coverage for the date conversion helper

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/AuroraChronos/AuroraChronosTest.php
- vendor/bin/phpstan analyse --memory-limit=512M *(fails: existing phpstan baseline issues in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb20b014c83288225aa9e269f5c5a