### PR TITLE
Fix month/year diff comparison and add coverage

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -160,18 +160,41 @@ class AuroraChronos
         }
 
         if (self::TIME_UNIT_MONTHS == $timeUnit) {
+            if ($interval->invert === 1) {
+                return false;
+            }
+
+            $monthsDiff = abs($this->monthsBetweenTwoDates($startDate, $endDate));
+            $hasRemainder = $interval->d > 0
+                || $interval->h > 0
+                || $interval->i > 0
+                || $interval->s > 0
+                || $interval->f > 0;
+
             return (
-                $this->monthsBetweenTwoDates($startDate, $endDate) > $intervalUnit
+                $monthsDiff > $intervalUnit
                 ||
-                ($this->monthsBetweenTwoDates($startDate, $endDate) == $intervalUnit && $interval->format('%r%s') > 0)
+                ($monthsDiff === $intervalUnit && $hasRemainder)
             );
         }
 
         if (self::TIME_UNIT_YEARS == $timeUnit) {
+            if ($interval->invert === 1) {
+                return false;
+            }
+
+            $yearsDiff = $this->yearsBetweenTwoDates($startDate, $endDate);
+            $hasRemainder = $interval->m > 0
+                || $interval->d > 0
+                || $interval->h > 0
+                || $interval->i > 0
+                || $interval->s > 0
+                || $interval->f > 0;
+
             return (
-                $this->yearsBetweenTwoDates($startDate, $endDate) > $intervalUnit
+                $yearsDiff > $intervalUnit
                 ||
-                ($this->yearsBetweenTwoDates($startDate, $endDate) == $intervalUnit && $interval->format('%r%s') > 0)
+                ($yearsDiff === $intervalUnit && $hasRemainder)
             );
         }
 

--- a/tests/SymfonyKernelTestCaseStub.php
+++ b/tests/SymfonyKernelTestCaseStub.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists(KernelTestCase::class, false)) {
+    abstract class KernelTestCase extends TestCase
+    {
+        protected static function bootKernel(array $options = []): object
+        {
+            return new class {
+                public function getContainer(): object
+                {
+                    return new class {
+                    };
+                }
+            };
+        }
+
+        protected static function ensureKernelShutdown(): void
+        {
+        }
+    }
+}

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -127,14 +127,63 @@ class AuroraChronosTest extends TestCase
                          'intervalUnit' => AuroraChronos::TIME_UNIT_WEEKS,
                          'expected'     => false
                      ],
-                     [
-                         'startDate'    => '2010-01-01 11:12:13',
-                         'endDate'      => '2010-01-08 11:12:14',
-                         'interval'     => 1,
-                         'intervalUnit' => AuroraChronos::TIME_UNIT_WEEKS,
-                         'expected'     => true
-                     ],
-                 ] as $test) {
+                    [
+                        'startDate'    => '2010-01-01 11:12:13',
+                        'endDate'      => '2010-01-08 11:12:14',
+                        'interval'     => 1,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_WEEKS,
+                        'expected'     => true
+                    ],
+                    [
+                        'startDate'    => '2024-01-01 00:00:00',
+                        'endDate'      => '2024-03-01 00:00:00',
+                        'interval'     => 1,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_MONTHS,
+                        'expected'     => true
+                    ],
+                    [
+                        'startDate'    => '2024-01-01 00:00:00',
+                        'endDate'      => '2024-02-01 00:00:00',
+                        'interval'     => 1,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_MONTHS,
+                        'expected'     => false
+                    ],
+                    [
+                        'startDate'    => '2024-01-01 00:00:00',
+                        'endDate'      => '2024-02-01 00:00:01',
+                        'interval'     => 1,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_MONTHS,
+                        'expected'     => true
+                    ],
+                    [
+                        'startDate'    => '2024-02-01 00:00:00',
+                        'endDate'      => '2024-01-01 00:00:00',
+                        'interval'     => 1,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_MONTHS,
+                        'expected'     => false
+                    ],
+                    [
+                        'startDate'    => '2020-01-01 00:00:00',
+                        'endDate'      => '2023-01-01 00:00:00',
+                        'interval'     => 2,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_YEARS,
+                        'expected'     => true
+                    ],
+                    [
+                        'startDate'    => '2024-01-01 00:00:00',
+                        'endDate'      => '2023-01-01 00:00:00',
+                        'interval'     => 0,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_YEARS,
+                        'expected'     => false
+                    ],
+                    [
+                        'startDate'    => '2020-01-01 00:00:00',
+                        'endDate'      => '2022-01-01 00:00:01',
+                        'interval'     => 2,
+                        'intervalUnit' => AuroraChronos::TIME_UNIT_YEARS,
+                        'expected'     => true
+                    ],
+                ] as $test) {
             $this->assertEquals($test['expected'], $Chronos->diffIsHigherThan($test['startDate'], $test['endDate'], $test['interval'], $test['intervalUnit']), json_encode($test));
         }
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,10 @@ if(is_file(dirname(__DIR__).'/vendor/autoload.php')) {
     require __DIR__.'/../vendor/autoload.php';
 }
 
+if (!class_exists(\Symfony\Bundle\FrameworkBundle\Test\KernelTestCase::class)) {
+    require __DIR__ . '/SymfonyKernelTestCaseStub.php';
+}
+
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
## Summary
- ensure `AuroraChronos::diffIsHigherThan()` treats month and year intervals as one-directional and flags fractional remainders
- extend `AuroraChronosTest::testDiffIsHigherThan` with scenarios covering month/year intervals and directionality
- load a lightweight `KernelTestCase` stub when Symfony's testing base class is unavailable so PHPUnit can execute in this environment

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraChronos/AuroraChronosTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68cbb81e52cc8328b620610bd4360de9