### PR TITLE
Fix session initialization in PWA main JS test

### DIFF
--- a/tests/Utils/PWA/PWAMainJsTest.php
+++ b/tests/Utils/PWA/PWAMainJsTest.php
@@ -218,6 +218,7 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\RequestStack;
     use Symfony\Component\HttpFoundation\Session\Session;
+    use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
     use Twig\Environment;
 
     /**
@@ -294,7 +295,20 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
                 }
             };
 
-            $session      = new Session(['PHPSESSID' => 'session-value']);
+            if (class_exists(MockArraySessionStorage::class)) {
+                $session = new Session(new MockArraySessionStorage());
+
+                if (method_exists($session, 'setId')) {
+                    $session->setId('session-value');
+                }
+
+                if (method_exists($session, 'set')) {
+                    $session->set('PHPSESSID', 'session-value');
+                }
+            } else {
+                $session = new Session(['PHPSESSID' => 'session-value']);
+            }
+
             $requestStack = new RequestStack($session);
             $twig         = new Environment();
             $pwa          = new PWA($container, $requestStack, $twig);


### PR DESCRIPTION
## Summary
- update the PWA main.js test to instantiate Symfony's Session with a mock storage when available
- keep a fallback for the lightweight session stub used when the Symfony component is absent
- ensure the test still seeds the expected PHPSESSID value for version generation

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/PWA/PWAMainJsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe2af60ec8328a5f74d5c92afd1b3