### PR TITLE
Fix session setup in PWAMainJs test

### DIFF
--- a/tests/Utils/PWA/PWAMainJsTest.php
+++ b/tests/Utils/PWA/PWAMainJsTest.php
@@ -164,6 +164,11 @@ namespace Symfony\Component\HttpFoundation\Session {
             {
                 return $this->values[$name] ?? $default;
             }
+
+            public function set(string $name, mixed $value): void
+            {
+                $this->values[$name] = $value;
+            }
         }
     }
 }
@@ -297,16 +302,18 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
 
             if (class_exists(MockArraySessionStorage::class)) {
                 $session = new Session(new MockArraySessionStorage());
-
-                if (method_exists($session, 'setId')) {
-                    $session->setId('session-value');
-                }
-
-                if (method_exists($session, 'set')) {
-                    $session->set('PHPSESSID', 'session-value');
-                }
             } else {
-                $session = new Session(['PHPSESSID' => 'session-value']);
+                $session = new Session();
+            }
+
+            if (method_exists($session, 'setId')) {
+                $session->setId('session-value');
+            }
+
+            if (method_exists($session, 'set')) {
+                $session->set('PHPSESSID', 'session-value');
+            } elseif (method_exists($session, 'replace')) {
+                $session->replace(['PHPSESSID' => 'session-value']);
             }
 
             $requestStack = new RequestStack($session);


### PR DESCRIPTION
## Summary
- update the Session test stub to support setting values
- adjust the PWAMainJs test to initialize the Symfony Session without deprecated arguments

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/PWA/PWAMainJsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe760d39c8328bc39157cf36a46de