### PR TITLE
Fix RequestStack setup in PWAMainJsTest

### DIFF
--- a/tests/Utils/PWA/PWAMainJsTest.php
+++ b/tests/Utils/PWA/PWAMainJsTest.php
@@ -316,10 +316,6 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
                 $session->replace(['PHPSESSID' => 'session-value']);
             }
 
-            $requestStack = new RequestStack($session);
-            $twig         = new Environment();
-            $pwa          = new PWA($container, $requestStack, $twig);
-
             $request = new class extends Request {
                 public \Symfony\Component\HttpFoundation\ParameterBag $cookies;
 
@@ -347,6 +343,23 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
                     return '/pwa/main.js';
                 }
             };
+
+            if (method_exists($request, 'setSession')) {
+                $request->setSession($session);
+            }
+
+            try {
+                $requestStack = new RequestStack($session);
+            } catch (\TypeError) {
+                $requestStack = new RequestStack();
+            }
+
+            if (method_exists($requestStack, 'push')) {
+                $requestStack->push($request);
+            }
+
+            $twig = new Environment();
+            $pwa  = new PWA($container, $requestStack, $twig);
 
             $response = $pwa->mainJS($request);
 


### PR DESCRIPTION
## Summary
- adjust `PWAMainJsTest` to build the request stack in a way that works with both the bundled stubs and Symfony's implementation
- attach the session to the request and push it onto the stack when supported before constructing the PWA instance

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist --filter testTranslationsUseExpectedKeys tests/Utils/PWA/PWAMainJsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68cbea7b7d5c83288061a0557000d0f4