### PR TITLE
Handle missing cookie bag when building PWA version string

### DIFF
--- a/src/Utils/PWA/PWA.php
+++ b/src/Utils/PWA/PWA.php
@@ -253,8 +253,24 @@ class PWA
         $version       = $serviceGit->getHash();
         $versionAppend = $this->container->getParameter('aurora.pwa.version_append');
 
-        if ($request->cookies->get('PHPSESSID')) {
-            $version .= '_' . $this->session->get('PHPSESSID');
+        $cookieSessionId = null;
+
+        if (property_exists($request, 'cookies') && is_object($request->cookies)) {
+            if (method_exists($request->cookies, 'get')) {
+                $cookieSessionId = $request->cookies->get('PHPSESSID');
+            }
+        } elseif (method_exists($request, 'cookies')) {
+            $cookiesBag = $request->cookies();
+            if (is_object($cookiesBag) && method_exists($cookiesBag, 'get')) {
+                $cookieSessionId = $cookiesBag->get('PHPSESSID');
+            }
+        }
+
+        if ($cookieSessionId && is_object($this->session) && method_exists($this->session, 'get')) {
+            $sessionIdentifier = $this->session->get('PHPSESSID');
+            if (null !== $sessionIdentifier && '' !== (string) $sessionIdentifier) {
+                $version .= '_' . (string) $sessionIdentifier;
+            }
         }
 
         if (0 === strpos($versionAppend, '!php/eval')) {

--- a/tests/Utils/PWA/PWAMainJsTest.php
+++ b/tests/Utils/PWA/PWAMainJsTest.php
@@ -97,6 +97,16 @@ namespace Symfony\Component\HttpFoundation {
             {
                 return $this->parameters[$key] ?? $default;
             }
+
+            public function set(string $key, mixed $value): void
+            {
+                $this->parameters[$key] = $value;
+            }
+
+            public function replace(array $parameters = []): void
+            {
+                $this->parameters = $parameters;
+            }
         }
     }
 
@@ -317,8 +327,6 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
             }
 
             $request = new class extends Request {
-                public \Symfony\Component\HttpFoundation\ParameterBag $cookies;
-
                 public function __construct()
                 {
                     parent::__construct(
@@ -330,7 +338,13 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
                         ['HTTP_HOST' => 'example.com', 'REQUEST_URI' => '/pwa/main.js']
                     );
 
-                    $this->cookies = new \Symfony\Component\HttpFoundation\ParameterBag(['PHPSESSID' => 'cookie-session']);
+                    if (property_exists($this, 'cookies') && is_object($this->cookies)) {
+                        if (method_exists($this->cookies, 'replace')) {
+                            $this->cookies->replace(['PHPSESSID' => 'cookie-session']);
+                        } elseif (method_exists($this->cookies, 'set')) {
+                            $this->cookies->set('PHPSESSID', 'cookie-session');
+                        }
+                    }
                 }
 
                 public function getHost(): string


### PR DESCRIPTION
## Summary
- ensure `PWA::version()` guards access to the request cookie bag and session before appending the session identifier
- enhance the PWA test double for `Request`/`ParameterBag` so cookies are initialized without redeclaring the parent property, keeping compatibility with Symfony's `InputBag`

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist --filter PWAMainJsTest`
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: existing codebase lacks required Symfony/Twig classes, yielding numerous static analysis errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf0ed5328832882a93c7061983b1b