### PR TITLE
Ensure PWAMainJs test works with real Twig

### DIFF
--- a/tests/Utils/PWA/PWAMainJsTest.php
+++ b/tests/Utils/PWA/PWAMainJsTest.php
@@ -357,7 +357,27 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
                 $requestStack->push($request);
             }
 
-            $twig = new Environment();
+            if (class_exists(\Twig\Loader\ArrayLoader::class)) {
+                $twig = new class () extends Environment {
+                    public ?array $lastContext = null;
+
+                    public function __construct()
+                    {
+                        parent::__construct(new \Twig\Loader\ArrayLoader([
+                            '@Aurora/pwa-main.js.twig' => '// rendered: @Aurora/pwa-main.js.twig',
+                        ]));
+                    }
+
+                    public function render(string $name, array $context = []): string
+                    {
+                        $this->lastContext = $context;
+
+                        return parent::render($name, $context);
+                    }
+                };
+            } else {
+                $twig = new Environment();
+            }
             $pwa  = new PWA($container, $requestStack, $twig);
 
             $response = $pwa->mainJS($request);


### PR DESCRIPTION
## Summary
- create an anonymous Twig environment subclass in `PWAMainJsTest` when Twig is installed
- seed the test Twig environment with the expected template so the captured rendering context remains available

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/PWA/PWAMainJsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cbfa4e9f1083288eb5c95bc1f7a25d