### PR TITLE
Fix Twig Environment test double signature

### DIFF
--- a/tests/Utils/PWA/PWAMainJsTest.php
+++ b/tests/Utils/PWA/PWAMainJsTest.php
@@ -410,11 +410,12 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
                         ]));
                     }
 
-                    public function render($name, array $context = []): string
+                    public function render(...$arguments): string
                     {
+                        $context            = is_array($arguments[1] ?? null) ? $arguments[1] : [];
                         $this->lastContext = $context;
 
-                        return parent::render($name, $context);
+                        return parent::render(...$arguments);
                     }
                 };
             } else {


### PR DESCRIPTION
## Summary
- adjust the Twig Environment test double to use a variadic render signature that captures the context without conflicting with Twig's method definition

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/PWA/PWAMainJsTest.php
- vendor/bin/phpstan analyse *(fails: memory limit exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0a663c6c832888ccc10980d606f0