### PR TITLE
Fix symbol requirement in password strength check

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -67,7 +67,8 @@ class AuroraMatch
         int   $maxLength = 999
     ): bool
     {
-        $match = '/^';
+        $password = (string) $password;
+        $match    = '/^';
 
         if ($min1LowerCase) {
             $match .= '(?=.*[a-z])';
@@ -81,12 +82,16 @@ class AuroraMatch
             $match .= '(?=.*[\d])';
         }
 
-        if ($min1Symbol && ctype_alnum($password)) {
-            return false;
+        if ($min1Symbol) {
+            if (preg_match('/^[\p{L}\p{N}]+$/u', $password)) {
+                return false;
+            }
+
+            $match .= '(?=.*[^\p{L}\p{N}])';
         }
 
         $match .= ".{{$minLength},{$maxLength}}";
-        $match .= '$/';
+        $match .= '$/u';
 
         return (bool)preg_match($match, $password);
     }

--- a/tests/Utils/AuroraMatch/AuroraMatchTest.php
+++ b/tests/Utils/AuroraMatch/AuroraMatchTest.php
@@ -258,6 +258,12 @@ body {
         $this->assertFalse($Match->passwordStrength('Tes1', true, true, true, true));
         $this->assertTrue($Match->passwordStrength('Te$1', true, true, true, true));
 
+        $this->assertFalse(
+            $Match->passwordStrength('Teă1', true, true, true, true),
+            'Unicode letters must not satisfy the symbol requirement.'
+        );
+        $this->assertTrue($Match->passwordStrength('Teă1$', true, true, true, true));
+
         $this->assertFalse($Match->passwordStrength('Te$1', true, true, true, true, 6));
         $this->assertFalse($Match->passwordStrength('Tekj12g4jh24v23jh523jh5g', true, true, true, true, 6));
         $this->assertTrue($Match->passwordStrength('Tekj12g4jh24v23jh523jh5g', true, true, true, false, 6));


### PR DESCRIPTION
## Summary
- make the passwordStrength helper treat the supplied password as a string and require a true symbol when configured
- ensure the symbol requirement uses Unicode-aware matching so non-ASCII letters do not satisfy it
- cover the regression with a dedicated PHPUnit assertion verifying Unicode letters alone do not pass the symbol requirement

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist --filter testPasswordStrength`
- `vendor/bin/phpstan analyse` *(fails: PHPStan process crashed because it reached configured PHP memory limit 128M)*

------
https://chatgpt.com/codex/tasks/task_e_68cc19e573c4832885ca2216550b9ba2