### PR TITLE
Trim human duration strings before parsing

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -441,9 +441,9 @@ class AuroraChronos
             'y' => 31536000       // 1 year (365 days) = 31536000 seconds
         ];
 
-        $timeStr = strtolower($timeStr);
+        $timeStr = strtolower(trim($timeStr));
 
-        if (!preg_match('/^(\d+)([hdwmy])$/', $timeStr, $matches)) {
+        if (!preg_match('/^(\d+)\s*([hdwmy])$/', $timeStr, $matches)) {
             return 0;
         }
 

--- a/tests/Utils/AuroraChronos/ConvertHumanTimeToSecondsTest.php
+++ b/tests/Utils/AuroraChronos/ConvertHumanTimeToSecondsTest.php
@@ -25,6 +25,8 @@ class ConvertHumanTimeToSecondsTest extends TestCase
         return [
             [3600, '1h'],
             [7200, '2H'],
+            [10800, ' 3h '],
+            [432000, '5 d'],
             [0, '10Z'],
         ];
     }


### PR DESCRIPTION
## Summary
- normalize whitespace in `convertHumanTimeToSeconds` before parsing the unit suffix
- permit optional spacing between the numeric value and unit designator
- expand the PHPUnit data provider to cover inputs with surrounding whitespace

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraChronos/ConvertHumanTimeToSecondsTest.php`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: missing framework dependencies such as Symfony HttpFoundation and Twig)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1d1b10308328ad9658a023d1155a