### PR TITLE
Prevent invalid cookie expires from causing type errors

### DIFF
--- a/src/Utils/AuroraCookiesExtractor/AuroraCookiesExtractor.php
+++ b/src/Utils/AuroraCookiesExtractor/AuroraCookiesExtractor.php
@@ -62,14 +62,18 @@ class AuroraCookiesExtractor
                 $normalized[strtolower($k)] = $v;
             }
 
+            $handledAttributes = [];
+
             // Path
             if (isset($normalized['path'])) {
                 $cookie->setPath($normalized['path']);
+                $handledAttributes[] = 'path';
             }
 
             // Domain
             if (isset($normalized['domain'])) {
                 $cookie->setDomain($normalized['domain']);
+                $handledAttributes[] = 'domain';
             }
 
             // Expires
@@ -80,11 +84,11 @@ class AuroraCookiesExtractor
                     // You can adjust according to the setExpires signature (DateTime|string|int).
                     // Below I pass timestamp (int); change if needed.
                     $cookie->setExpires(new \DateTimeImmutable('@' . $ts, new \DateTimeZone('UTC')));
-                } else {
-                    $cookie->setExpires($normalized['expires']);
+                    $handledAttributes[] = 'expires';
                 }
             } elseif (isset($normalized['max-age'])) {
                 $cookie->setExpires(new \DateTimeImmutable('@' . (time() + (int) $normalized['max-age']), new \DateTimeZone('UTC')));
+                $handledAttributes[] = 'max-age';
             } elseif ('PHPSESSID' === $name) {
                 // Set expires to 1440 seconds from now (default PHP session.gc_maxlifetime)
                 $cookie->setExpires(new \DateTimeImmutable('+1440 seconds', new \DateTimeZone('UTC')));
@@ -93,21 +97,24 @@ class AuroraCookiesExtractor
             // SameSite
             if (isset($normalized['samesite'])) {
                 $cookie->setSameSite($normalized['samesite']);
+                $handledAttributes[] = 'samesite';
             }
 
             // Flags Secure / HttpOnly
             if ((isset($normalized['secure']) && $normalized['secure'] === true)) {
                 $cookie->setSecure(true);
+                $handledAttributes[] = 'secure';
             }
             if ((isset($normalized['httponly']) && $normalized['httponly'] === true)) {
                 $cookie->setHttpOnly(true);
+                $handledAttributes[] = 'httponly';
             }
 
             // Fallback: if setAttributes(array) or setAttribute(k,v) exists, set the rest
             $leftovers = $attrs;
 
             // Remove those already handled
-            foreach (['path', 'domain', 'expires', 'max-age', 'samesite', 'secure', 'httponly'] as $done) {
+            foreach ($handledAttributes as $done) {
                 foreach (array_keys($leftovers) as $k) {
                     if (strcasecmp($k, $done) === 0) {
                         unset($leftovers[$k]);

--- a/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php
+++ b/tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php
@@ -56,5 +56,29 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCookiesExtractor {
             $this->assertSame('test', $cookies[0]->getName());
             $this->assertSame('1', $cookies[0]->getValue());
         }
+
+        public function testInvalidExpiresStringPreservesAttribute(): void
+        {
+            $response = new class implements ResponseInterface {
+                public function getInfo(?string $type = null): mixed
+                {
+                    return [
+                        'response_headers' => ['Set-Cookie: token=value; Expires=Not a valid date; Secure']
+                    ];
+                }
+            };
+
+            $extractor = new AuroraCookiesExtractor();
+            $cookies = $extractor->extractFromSymfonyResponseInterface($response);
+
+            $this->assertCount(1, $cookies);
+            $cookie = $cookies[0];
+
+            $this->assertNull($cookie->getExpires());
+            $this->assertSame(
+                ['Expires' => 'Not a valid date'],
+                $cookie->getAttributes()
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid calling Cookie::setExpires() with raw strings when parsing the Expires attribute fails
- track handled cookie attributes so only processed entries are stripped from the attribute list
- add a regression test that exercises cookies whose Expires value cannot be parsed and ensures the original data is preserved

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/AuroraCookiesExtractor/AuroraCookiesExtractorExtractTest.php
- vendor/bin/phpstan analyse --memory-limit=512M *(fails: project lacks Symfony/Twig classes required by static analysis)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1f060a9c8328919baeac94f521e8