### PR TITLE
Handle OpenSSL decryption failures

### DIFF
--- a/src/Utils/AuroraCryptor/AuroraCryptor.php
+++ b/src/Utils/AuroraCryptor/AuroraCryptor.php
@@ -97,7 +97,11 @@ class AuroraCryptor
         $decrypted = openssl_decrypt($data, $this->cipher, $this->encryptionKey, $this->options, $vector);
         $this->encryptionKey = null;
 
-        return (string) $decrypted;
+        if ($decrypted === false) {
+            throw new \RuntimeException('Unable to decrypt the provided data.');
+        }
+
+        return $decrypted;
     }
 
     /**

--- a/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
+++ b/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCryptor;
 
 use InvalidArgumentException;
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraCryptor\AuroraCryptor;
 
@@ -63,6 +64,25 @@ class AuroraCryptorTest extends TestCase
         $this->expectExceptionMessage('Encrypted payload must be valid base64.');
 
         $cryptor->setEncryptionKey('test')->decrypt('not-base64');
+    }
+
+    public function testDecryptThrowsWhenDecryptionFails(): void
+    {
+        $cryptor = new AuroraCryptor();
+        $cryptor->setCipher('AES-128-CBC');
+        $key     = '0123456789abcdef';
+        $payload = $cryptor->setEncryptionKey($key)->encrypt('secret-data');
+
+        $decoded = base64_decode($payload, true);
+        $this->assertNotFalse($decoded);
+
+        [$data, $vector] = explode('::', $decoded, 2);
+        $tamperedPayload = base64_encode(substr($data, 0, 2) . '::' . $vector);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to decrypt the provided data.');
+
+        $cryptor->setEncryptionKey($key)->decrypt($tamperedPayload);
     }
 
     public function testSha256To32BitUnsigned(): void


### PR DESCRIPTION
## Summary
- throw a runtime exception when `openssl_decrypt` returns `false` so decryption failures are surfaced
- add a PHPUnit test that tampers with the encrypted payload to cover the new error path

## Testing
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraCryptor`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: missing Symfony components in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd30532ea88328b6785a3ab73adac0