### PR TITLE
Support ISO-8601 offsets without colon in guessDateTimeFormat

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -50,6 +50,14 @@ class AuroraChronos
             return 'Y-m-d\TH:i:s.vP';
         }
 
+        if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+\-]\d{4}$/', $datetime)) {
+            return 'Y-m-d\TH:i:sO';
+        }
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+\-]\d{4}$/', $datetime)) {
+            return 'Y-m-d\TH:i:s.vO';
+        }
+
         if (preg_match('/^\d{2}\/\d{2}\/\d{4}$/', $datetime)) {
             return 'm/d/Y';
         }

--- a/tests/Utils/AuroraChronos/GuessDateTimeFormatTest.php
+++ b/tests/Utils/AuroraChronos/GuessDateTimeFormatTest.php
@@ -35,6 +35,8 @@ class GuessDateTimeFormatTest extends TestCase
             ['Y-m-d\\TH:i:s.v\\Z', '2024-05-30T14:23:59.123Z'],
             ['Y-m-d\\TH:i:sP', '2024-05-30T14:23:59+02:00'],
             ['Y-m-d\\TH:i:s.vP', '2024-05-30T14:23:59.123+02:00'],
+            ['Y-m-d\\TH:i:sO', '2024-05-30T14:23:59+0200'],
+            ['Y-m-d\\TH:i:s.vO', '2024-05-30T14:23:59.123-0530'],
             ['m/d/Y', '05/30/2024'],
             ['d.m.Y', '30.05.2024'],
             [null, 'invalid-format'],


### PR DESCRIPTION
## Summary
- teach `AuroraChronos::guessDateTimeFormat()` to recognise ISO-8601 timestamps whose timezone offsets omit the colon separator
- extend the GuessDateTimeFormat test data set with cases covering offsets like `+0200` and `-0530`

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/AuroraChronos/GuessDateTimeFormatTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd4e1baef88328bb2a21fe16aa6212