### PR TITLE
Fix parsing of Accept-Language quality weights

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -218,13 +218,43 @@ class AuroraClient
         $prefLanguages = [];
 
         if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-            $prefLanguages = array_reduce(
-                explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']),
-                function ($res, $el) {
-                    [$l, $q] = array_merge(explode(';q=', trim($el)), [1]);
-                    $res[trim($l)] = (float) $q;
-                    return $res;
-                }, []);
+            $languages = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+
+            foreach ($languages as $language) {
+                $language = trim($language);
+
+                if ($language === '') {
+                    continue;
+                }
+
+                $parts   = array_map('trim', explode(';', $language));
+                $locale  = array_shift($parts);
+                $quality = 1.0;
+
+                if ($locale === '' || $locale === null) {
+                    continue;
+                }
+
+                foreach ($parts as $part) {
+                    if ($part === '') {
+                        continue;
+                    }
+
+                    if (!str_contains($part, '=')) {
+                        continue;
+                    }
+
+                    [$key, $value] = array_map('trim', explode('=', $part, 2));
+
+                    if (strcasecmp($key, 'q') === 0 && is_numeric($value)) {
+                        $quality = (float) $value;
+                        break;
+                    }
+                }
+
+                $prefLanguages[$locale] = $quality;
+            }
+
             arsort($prefLanguages);
         }
 

--- a/tests/Utils/AuroraClient/AuroraClientPreferredLanguagesStandaloneTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientPreferredLanguagesStandaloneTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+
+final class AuroraClientPreferredLanguagesStandaloneTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+    }
+
+    public function testPreferredLanguagesHandlesWhitespaceAroundQuality(): void
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US; q=0.8, fr; q=0.6';
+        $client = new AuroraClient();
+
+        $this->assertSame(
+            [
+                'en-US' => 0.8,
+                'fr'    => 0.6,
+            ],
+            $client->preferredLanguages()
+        );
+    }
+
+    public function testPreferredLanguagesIsCaseInsensitiveForQualityKey(): void
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'es-ES, de; Q=0.4';
+        $client = new AuroraClient();
+
+        $this->assertSame(
+            [
+                'es-ES' => 1.0,
+                'de'    => 0.4,
+            ],
+            $client->preferredLanguages()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- make preferredLanguages parse q parameters that include optional whitespace and ignore case
- add standalone PHPUnit coverage for Accept-Language headers with whitespace and uppercase quality keys

## Testing
- `vendor/bin/phpunit --no-coverage tests/Utils/AuroraClient/AuroraClientPreferredLanguagesStandaloneTest.php`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: missing Symfony-related symbols in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7be98dd08328aedbdcd210f0dddf