### PR TITLE
Add seconds support to time string conversion

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -437,11 +437,12 @@ class AuroraChronos
 
     /**
      * Convert a time string to seconds
-     *   eg: 1h => 3600, 2d => 172800, 3w => 1814400, 4m => 10368000, 5y => 157680000
+     *   eg: 30s => 30, 1h => 3600, 2d => 172800, 3w => 1814400, 4m => 10368000, 5y => 157680000
      */
     function convertHumanTimeToSeconds(string $timeStr): int
     {
         $timeUnits = [
+            's' => 1,             // 1 second = 1 second
             'h' => 3600,          // 1 hour = 3600 seconds
             'd' => 86400,         // 1 day = 86400 seconds
             'w' => 604800,        // 1 week = 604800 seconds
@@ -451,7 +452,7 @@ class AuroraChronos
 
         $timeStr = strtolower(trim($timeStr));
 
-        if (!preg_match('/^(\d+)\s*([hdwmy])$/', $timeStr, $matches)) {
+        if (!preg_match('/^(\d+)\s*([shdwmy])$/', $timeStr, $matches)) {
             return 0;
         }
 

--- a/tests/Utils/AuroraChronos/ConvertHumanTimeToSecondsTest.php
+++ b/tests/Utils/AuroraChronos/ConvertHumanTimeToSecondsTest.php
@@ -23,6 +23,7 @@ class ConvertHumanTimeToSecondsTest extends TestCase
     public static function dataConvertHumanTimeToSeconds(): array
     {
         return [
+            [30, '30s'],
             [3600, '1h'],
             [7200, '2H'],
             [10800, ' 3h '],


### PR DESCRIPTION
## Summary
- add support for second-based duration strings in `AuroraChronos::convertHumanTimeToSeconds`
- document the new capability in the method PHPDoc
- cover second conversions with an additional PHPUnit data provider case

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraChronos/ConvertHumanTimeToSecondsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd85e5b5e48328a4d60a1d39ea611d