### PR TITLE
Trim forwarded IP header before validation

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -164,16 +164,22 @@ class AuroraClient
             return $_SERVER['HTTP_CF_CONNECTING_IP'];
         }
 
-        if (
-            isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-            && false === strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',')
-            && $this->ipIsValid($_SERVER['HTTP_X_FORWARDED_FOR'])
-        ) {
-            return $_SERVER['HTTP_X_FORWARDED_FOR'];
+        $forwardedForHeader = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? null;
+
+        if (is_string($forwardedForHeader)) {
+            $forwardedForSingleIp = trim($forwardedForHeader);
+
+            if (
+                $forwardedForSingleIp !== ''
+                && false === strpos($forwardedForHeader, ',')
+                && $this->ipIsValid($forwardedForSingleIp)
+            ) {
+                return $forwardedForSingleIp;
+            }
         }
 
-        if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') !== false) {
-            foreach (explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']) as $ip) {
+        if (is_string($forwardedForHeader) && strpos($forwardedForHeader, ',') !== false) {
+            foreach (explode(',', $forwardedForHeader) as $ip) {
                 $ip = trim($ip);
                 if ($this->ipIsValid($ip)) {
                     return $ip;

--- a/tests/Utils/AuroraClient/AuroraClientIpTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientIpTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+use Symfony\Component\HttpFoundation\Request;
+
+class AuroraClientIpTest extends TestCase
+{
+    public function testIpTrimsSingleForwardedHeader(): void
+    {
+        $request = Request::create(
+            '/',
+            'GET',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => '198.51.100.5']
+        );
+
+        $originalServer = $_SERVER;
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = ' 203.0.113.10 ';
+
+        $client = new AuroraClient();
+
+        try {
+            $this->assertSame('203.0.113.10', $client->ip($request));
+        } finally {
+            $_SERVER = $originalServer;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- trim single-valued X-Forwarded-For headers before validation so the client IP detection accepts values with surrounding whitespace
- add a PHPUnit test covering the whitespace trimming behaviour of AuroraClient::ip

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraClient/AuroraClientIpTest.php`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: existing codebase is not PHPStan-clean; see output for details)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8aee9e3c83289cbc32e19c429f0a