### PR TITLE
Handle comma-separated forwarded proto header

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -135,7 +135,35 @@ class AuroraClient
     {
         // Reverse proxy
         if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
-            return $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://';
+            $forwardedProto = $_SERVER['HTTP_X_FORWARDED_PROTO'];
+
+            if (is_string($forwardedProto)) {
+                $candidates = explode(',', $forwardedProto);
+
+                foreach ($candidates as $candidate) {
+                    $candidate = trim($candidate);
+
+                    if ($candidate === '') {
+                        continue;
+                    }
+
+                    $normalized = strtolower($candidate);
+
+                    if (str_contains($normalized, '://')) {
+                        [$normalized] = explode('://', $normalized, 2);
+                    }
+
+                    if ($normalized === 'https') {
+                        return 'https://';
+                    }
+
+                    if ($normalized === 'http') {
+                        return 'http://';
+                    }
+
+                    return $normalized . '://';
+                }
+            }
         }
 
         if (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off') {

--- a/tests/Utils/AuroraClient/AuroraClientProtocolTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientProtocolTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+
+final class AuroraClientProtocolTest extends TestCase
+{
+    private array $originalServer;
+
+    protected function setUp(): void
+    {
+        $this->originalServer = $_SERVER;
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->originalServer;
+    }
+
+    public function testProtocolUsesFirstForwardedProtoValue(): void
+    {
+        $client = new AuroraClient();
+
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https, http';
+        self::assertSame('https://', $client->protocol());
+
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'HTTP,https';
+        self::assertSame('http://', $client->protocol());
+    }
+
+    public function testProtocolSkipsEmptyForwardedProtoEntries(): void
+    {
+        $client = new AuroraClient();
+
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = '  , https ';
+        self::assertSame('https://', $client->protocol());
+    }
+}


### PR DESCRIPTION
## Summary
- normalize the X-Forwarded-Proto header so the first non-empty value determines the scheme
- add dedicated unit tests around AuroraClient::protocol for mixed forwarded proto values

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/AuroraClient/AuroraClientProtocolTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd90267584832884aed070e78bc613