### PR TITLE
Fix boolean parsing for PWA automatic prompt

### DIFF
--- a/src/Utils/PWA/PWA.php
+++ b/src/Utils/PWA/PWA.php
@@ -221,11 +221,28 @@ class PWA
             }
         }
 
+        $automaticallyPrompt = true;
+
+        if ($this->container->hasParameter('aurora.pwa.automatically_prompt')) {
+            $rawAutomaticallyPrompt = $this->container->getParameter('aurora.pwa.automatically_prompt');
+            $parsedAutomaticallyPrompt = filter_var(
+                $rawAutomaticallyPrompt,
+                FILTER_VALIDATE_BOOLEAN,
+                FILTER_NULL_ON_FAILURE
+            );
+
+            if (null !== $parsedAutomaticallyPrompt) {
+                $automaticallyPrompt = $parsedAutomaticallyPrompt;
+            } else {
+                $automaticallyPrompt = (bool) $rawAutomaticallyPrompt;
+            }
+        }
+
         $rendered = $this->twig->render('@Aurora/pwa-main.js.twig', [
             'pwaDebug'             => filter_var($this->container->getParameter('aurora.pwa.debug') ?? false, FILTER_VALIDATE_BOOLEAN),
             'pwaVersion'           => $this->version($request),
             'hostName'             => $request->getHost(),
-            'automatically_prompt' => ($this->container->hasParameter('aurora.pwa.automatically_prompt') ? boolval($this->container->getParameter('aurora.pwa.automatically_prompt')) : true),
+            'automatically_prompt' => $automaticallyPrompt,
             'translations'         => [
                 'notificationInstallTheApp' => addslashes($notificationInstallTheApp),
                 'notificationNewVersion'     => addslashes($notificationNewVersion),

--- a/tests/Utils/PWA/PWAMainJsTest.php
+++ b/tests/Utils/PWA/PWAMainJsTest.php
@@ -241,33 +241,36 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
      */
     final class PWAMainJsTest extends TestCase
     {
-        public function testTranslationsUseExpectedKeys(): void
+        /**
+         * @return array{0:PWA,1:Request,2:Environment}
+         */
+        private function createMainJsScenario(array $parameterOverrides = []): array
         {
-            $container = new class implements ContainerInterface {
+            $container = new class ($parameterOverrides) implements ContainerInterface {
                 /** @var array<string, mixed> */
-                private array $parameters
-                    = [
-                        'aurora.pwa.enabled'              => true,
-                        'aurora.pwa.debug'                => false,
-                        'aurora.pwa.automatically_prompt' => true,
-                        'aurora.pwa.version_append'       => '',
-                        'kernel.environment'              => 'dev',
-                    ];
+                private array $parameters = [
+                    'aurora.pwa.enabled'              => true,
+                    'aurora.pwa.debug'                => false,
+                    'aurora.pwa.automatically_prompt' => true,
+                    'aurora.pwa.version_append'       => '',
+                    'kernel.environment'              => 'dev',
+                ];
 
                 /** @var array<string, mixed> */
-                private array $services
-                    = [
-                        'aurora.git' => null,
-                    ];
+                private array $services = [];
 
-                public function __construct()
+                public function __construct(array $overrides = [])
                 {
-                    $this->services['aurora.git'] = new class {
-                        public function getHash(): string
-                        {
-                            return 'hash-value';
-                        }
-                    };
+                    $this->parameters = array_merge($this->parameters, $overrides);
+
+                    $this->services = [
+                        'aurora.git' => new class {
+                            public function getHash(): string
+                            {
+                                return 'hash-value';
+                            }
+                        },
+                    ];
                 }
 
                 public function get(string $id, int $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE): ?object
@@ -421,7 +424,15 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
             } else {
                 $twig = new Environment();
             }
-            $pwa  = new PWA($container, $requestStack, $twig);
+
+            $pwa = new PWA($container, $requestStack, $twig);
+
+            return [$pwa, $request, $twig];
+        }
+
+        public function testTranslationsUseExpectedKeys(): void
+        {
+            [$pwa, $request, $twig] = $this->createMainJsScenario();
 
             $response = $pwa->mainJS($request);
 
@@ -436,6 +447,19 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\PWA {
             self::assertArrayHasKey('notificationInstallTheApp', $translations);
             self::assertArrayNotHasKey('nnotificationInstallTheApp', $translations);
             self::assertSame('Install the App', $translations['notificationInstallTheApp']);
+        }
+
+        public function testAutomaticallyPromptRespectsBooleanStrings(): void
+        {
+            [$pwa, $request, $twig] = $this->createMainJsScenario([
+                'aurora.pwa.automatically_prompt' => 'false',
+            ]);
+
+            $pwa->mainJS($request);
+
+            self::assertIsArray($twig->lastContext);
+            self::assertArrayHasKey('automatically_prompt', $twig->lastContext);
+            self::assertFalse($twig->lastContext['automatically_prompt']);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `PWA::mainJS()` converts the aurora.pwa.automatically_prompt parameter using `FILTER_VALIDATE_BOOLEAN`
- refactor the PWA main.js test fixture creation into a helper and add coverage for boolean string handling

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/PWA/PWAMainJsTest.php
- vendor/bin/phpunit --no-coverage tests/Utils/PWA/PWACacheTest.php
- vendor/bin/phpstan analyse --memory-limit=512M *(fails: missing Symfony components in the standalone bundle environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd986ddbe88328ac3766d4e5f9c6b5