### PR TITLE
Fix recursive delete failure handling

### DIFF
--- a/src/Utils/IO/IO.php
+++ b/src/Utils/IO/IO.php
@@ -35,22 +35,29 @@ class IO
             return @unlink($str);
         }
 
-        if (is_dir($str)) {
-            $items = @scandir($str);
-            if (is_array($items)) {
-                foreach (array_diff($items, ['.', '..']) as $item) {
-                    $this->recursiveDelete($str . '/' . $item);
-                }
-            }
-
-            if ($removeGivenDir) {
-                return @rmdir($str);
-            }
-
-            return true;
+        if (!is_dir($str)) {
+            return false;
         }
 
-        return false;
+        $items  = @scandir($str);
+        $result = true;
+
+        if ($items === false) {
+            $result = false;
+            $items  = [];
+        }
+
+        foreach (array_diff($items, ['.', '..']) as $item) {
+            if (!$this->recursiveDelete($str . '/' . $item)) {
+                $result = false;
+            }
+        }
+
+        if ($removeGivenDir) {
+            return $result && @rmdir($str);
+        }
+
+        return $result;
     }
 
     public function dirIsEmpty(string $directory): bool

--- a/tests/Utils/IO/IOTest.php
+++ b/tests/Utils/IO/IOTest.php
@@ -55,6 +55,44 @@ class IOTest extends TestCase
         rmdir($dir);
     }
 
+    public function testRecursiveDeleteReturnsFalseWhenDeletionFails(): void
+    {
+        if (!function_exists('posix_geteuid') || !function_exists('posix_seteuid')) {
+            $this->markTestSkipped('POSIX functions are required for this test.');
+        }
+
+        if (posix_geteuid() !== 0) {
+            $this->markTestSkipped('This test requires root privileges to drop permissions temporarily.');
+        }
+
+        $nobody = posix_getpwnam('nobody');
+        if (false === $nobody) {
+            $this->markTestSkipped('User "nobody" is required for this test.');
+        }
+
+        $IO           = new IO();
+        $dir          = sys_get_temp_dir() . '/aurora_' . uniqid();
+        $file         = $dir . '/file.txt';
+        $originalEuid = posix_geteuid();
+
+        mkdir($dir, 0700);
+        file_put_contents($file, 'content');
+
+        try {
+            $this->assertTrue(posix_seteuid((int) $nobody['uid']));
+            $this->assertFalse($IO->recursiveDelete($dir, false));
+        } finally {
+            posix_seteuid($originalEuid);
+        }
+
+        try {
+            $this->assertFileExists($file);
+        } finally {
+            unlink($file);
+            rmdir($dir);
+        }
+    }
+
     public function testDirIsEmptyHandlesMissingDirectory(): void
     {
         $IO          = new IO();


### PR DESCRIPTION
## Summary
- ensure IO::recursiveDelete propagates failures from nested deletions
- add PHPUnit coverage for failure scenarios by dropping privileges temporarily

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/IO/IOTest.php
- vendor/bin/phpstan analyse --memory-limit=1G src/Utils/IO/IO.php tests/Utils/IO/IOTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd9c54cca48328853da79eab738f1e