### PR TITLE
Ensure PWACache tests provide a session to requests

### DIFF
--- a/tests/Utils/PWA/PWACacheTest.php
+++ b/tests/Utils/PWA/PWACacheTest.php
@@ -614,6 +614,10 @@ final class PWACacheTest extends TestCase
             $requestStack = new RequestStack();
         }
 
+        if (method_exists($request, 'setSession')) {
+            $request->setSession($session);
+        }
+
         if (method_exists($requestStack, 'push')) {
             $requestStack->push($request);
         }


### PR DESCRIPTION
## Summary
- attach the mocked session to the request used in PWACache tests so Symfony's RequestStack exposes it when available

## Testing
- vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/PWA/PWACacheTest.php
- vendor/bin/phpstan analyse --memory-limit=1G *(fails: existing code base contains numerous analysis errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaf1a8824832887cc0f1698620d32