### PR TITLE
Preserve protocol relative URLs when compressing slashes

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -44,7 +44,25 @@ class Strink
      */
     public function compressSlashes(): self
     {
-        $this->string = preg_replace('~(^|[^:])//+~', '\1/', $this->string);
+        $workingString           = $this->string;
+        $preserveProtocolPrefix = false;
+
+        if (str_starts_with($workingString, '//') && (strlen($workingString) === 2 || $workingString[2] !== '/')) {
+            $preserveProtocolPrefix = true;
+            $workingString          = '__AURORA_PROTOCOL_RELATIVE__' . substr($workingString, 2);
+        }
+
+        $collapsed = preg_replace('~(^|[^:])//+~', '\1/', $workingString);
+
+        if ($collapsed === null) {
+            $collapsed = $workingString;
+        }
+
+        if ($preserveProtocolPrefix) {
+            $collapsed = preg_replace('/^__AURORA_PROTOCOL_RELATIVE__/', '//', $collapsed, 1) ?? $collapsed;
+        }
+
+        $this->string = $collapsed;
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -135,6 +135,8 @@ class StrinkTest extends TestCase
         $Strink = new Strink();
         $this->assertEquals('http://example.com/foo/bar', $Strink->string('http://example.com//foo///bar')->compressSlashes());
         $this->assertEquals('/foo/bar', $Strink->string('////foo//bar')->compressSlashes());
+        $this->assertEquals('//example.com/path', $Strink->string('//example.com/path')->compressSlashes());
+        $this->assertEquals('//example.com/path', $Strink->string('//example.com//path')->compressSlashes());
     }
 
     public function testCompressDoubleQuotes(): void


### PR DESCRIPTION
## Summary
- avoid collapsing leading protocol-relative double slashes when normalising slash sequences
- cover protocol-relative URL handling with new Strink utility tests

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/Strink/StrinkTest.php
- vendor/bin/phpstan analyse --memory-limit=512M *(fails: Symfony classes missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb99d7d0483288627cf89e32119eb