### PR TITLE
Ensure maskable icon test file contains valid PNG

### DIFF
--- a/tests/Utils/PWA/PWACacheTest.php
+++ b/tests/Utils/PWA/PWACacheTest.php
@@ -483,7 +483,12 @@ final class PWACacheTest extends TestCase
             file_put_contents($directory . DIRECTORY_SEPARATOR . "android-icon-{$size}x{$size}.png", '');
         }
 
-        file_put_contents($directory . DIRECTORY_SEPARATOR . 'android-icon-maskable.png', '');
+        $minimalPng = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HwAFgwJ/lXzyNwAAAABJRU5ErkJggg==', true);
+        if (false === $minimalPng) {
+            self::fail('Unable to decode the minimal PNG used for testing.');
+        }
+
+        file_put_contents($directory . DIRECTORY_SEPARATOR . 'android-icon-maskable.png', $minimalPng);
 
         $this->tempDirectories[] = $directory;
 


### PR DESCRIPTION
## Summary
- provide a minimal PNG payload for the maskable PWA icon fixture used in tests
- add a guard to fail fast if the embedded PNG data cannot be decoded

## Testing
- `./vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/PWA/PWACacheTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68cf154660608328a22f710230b81d2d