### PR TITLE
Fix domain matching for hosts with ports

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -7,14 +7,25 @@ class AuroraMatch
     public function matchDomain(string $needle, string $domain): bool
     {
         $parsedNeedle = parse_url($needle);
-        if ($parsedNeedle !== false && isset($parsedNeedle['scheme'], $parsedNeedle['host'])) {
-            $needle = $parsedNeedle['host'];
+        if (false !== $parsedNeedle) {
+            if (isset($parsedNeedle['host'])) {
+                $needle = $parsedNeedle['host'];
+            } elseif (!isset($parsedNeedle['scheme']) && isset($parsedNeedle['path'])) {
+                $needle = $parsedNeedle['path'];
+            }
         }
 
         $parsedDomain = parse_url($domain);
-        if ($parsedDomain !== false && isset($parsedDomain['scheme'], $parsedDomain['host'])) {
-            $domain = $parsedDomain['host'];
+        if (false !== $parsedDomain) {
+            if (isset($parsedDomain['host'])) {
+                $domain = $parsedDomain['host'];
+            } elseif (!isset($parsedDomain['scheme']) && isset($parsedDomain['path'])) {
+                $domain = $parsedDomain['path'];
+            }
         }
+
+        $needle = rtrim($needle, '.');
+        $domain = rtrim($domain, '.');
 
         $needle = strtolower($needle);
         $domain = strtolower($domain);

--- a/tests/Utils/AuroraMatch/AuroraMatchTest.php
+++ b/tests/Utils/AuroraMatch/AuroraMatchTest.php
@@ -82,6 +82,21 @@ class AuroraMatchTest extends TestCase
                 'expected' => true,
             ],
             [
+                'needle'   => 'sindla.com:8080',
+                'domain'   => 'sindla.com',
+                'expected' => true,
+            ],
+            [
+                'needle'   => 'sub.domain.sindla.com:8443',
+                'domain'   => 'sindla.com',
+                'expected' => true,
+            ],
+            [
+                'needle'   => 'sindla.com.',
+                'domain'   => 'sindla.com',
+                'expected' => true,
+            ],
+            [
                 'needle'   => 'sindla.com',
                 'domain'   => 'sindla.com',
                 'expected' => true,


### PR DESCRIPTION
## Summary
- ensure `AuroraMatch::matchDomain()` normalizes host names that include explicit ports or trailing dots before matching
- extend the AuroraMatch test matrix to cover host strings with ports and trailing dots

## Testing
- `vendor/bin/phpunit --no-coverage -c phpunit.xml.dist tests/Utils/AuroraMatch/AuroraMatchTest.php`
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: project dependencies such as Twig and Symfony components are not present in the constrained test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf247c72388328b8f98863fca5d723