### PR TITLE
Allow documentation IP ranges in AuroraClient validation

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -9,6 +9,12 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AuroraClient
 {
+    private const DOCUMENTATION_CIDRS = [
+        '192.0.2.0/24',    // TEST-NET-1
+        '198.51.100.0/24', // TEST-NET-2
+        '203.0.113.0/24',  // TEST-NET-3
+        '2001:db8::/32',   // IPv6 documentation prefix
+    ];
     private $geoLiteCountryReader;
     private $geoLiteCityReader;
     private $geoLiteASNReader;
@@ -235,13 +241,86 @@ class AuroraClient
      */
     public function ipIsValid(mixed $ip): bool
     {
+        if (!is_string($ip) && !is_numeric($ip)) {
+            return false;
+        }
+
+        $ipString = trim((string) $ip);
+
+        if ($ipString === '') {
+            return false;
+        }
+
+        if (filter_var($ipString, FILTER_VALIDATE_IP) === false) {
+            return false;
+        }
+
+        if ($this->isDocumentationIp($ipString)) {
+            return true;
+        }
+
         $ipIsValid = filter_var(
-            $ip,
+            $ipString,
             FILTER_VALIDATE_IP,
             FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
         );
 
         return $ipIsValid !== false;
+    }
+
+    private function isDocumentationIp(string $ip): bool
+    {
+        foreach (self::DOCUMENTATION_CIDRS as $cidr) {
+            if ($this->ipMatchesCidr($ip, $cidr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function ipMatchesCidr(string $ip, string $cidr): bool
+    {
+        if (strpos($cidr, '/') === false) {
+            return false;
+        }
+
+        [$subnet, $prefixLength] = explode('/', $cidr, 2);
+
+        if ($subnet === '') {
+            return false;
+        }
+
+        $prefixLength = (int) trim($prefixLength);
+        $ipBinary     = inet_pton($ip);
+        $subnetBinary = inet_pton($subnet);
+
+        if (
+            $ipBinary === false
+            || $subnetBinary === false
+            || strlen($ipBinary) !== strlen($subnetBinary)
+            || $prefixLength < 0
+        ) {
+            return false;
+        }
+
+        $totalBits = strlen($ipBinary) * 8;
+
+        if ($prefixLength > $totalBits) {
+            return false;
+        }
+
+        $maskBytes = intdiv($prefixLength, 8);
+        $mask      = str_repeat("\xff", $maskBytes);
+        $remainder = $prefixLength % 8;
+
+        if ($remainder > 0) {
+            $mask .= chr((0xff << (8 - $remainder)) & 0xff);
+        }
+
+        $mask = str_pad($mask, strlen($ipBinary), "\0");
+
+        return ($ipBinary & $mask) === ($subnetBinary & $mask);
     }
 
     /**

--- a/tests/Utils/AuroraClient/AuroraClientIpValidationTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientIpValidationTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+
+class AuroraClientIpValidationTest extends TestCase
+{
+    #[DataProvider('provideDocumentationIps')]
+    public function testIpIsValidAllowsDocumentationRanges(string $ip): void
+    {
+        $client = new AuroraClient();
+
+        $this->assertTrue(
+            $client->ipIsValid($ip),
+            sprintf('Expected documentation IP %s to be considered valid.', $ip)
+        );
+    }
+
+    public static function provideDocumentationIps(): array
+    {
+        return [
+            'TEST-NET-1' => ['192.0.2.10'],
+            'TEST-NET-2' => ['198.51.100.23'],
+            'TEST-NET-3' => ['203.0.113.42'],
+            'IPv6 documentation prefix' => ['2001:db8::1'],
+        ];
+    }
+
+    #[DataProvider('provideInvalidIps')]
+    public function testIpIsValidStillRejectsLocalAddresses(string $ip): void
+    {
+        $client = new AuroraClient();
+
+        $this->assertFalse(
+            $client->ipIsValid($ip),
+            sprintf('Expected %s to be considered invalid.', $ip)
+        );
+    }
+
+    public static function provideInvalidIps(): array
+    {
+        return [
+            'empty string' => [''],
+            'loopback IPv6' => ['::1'],
+            'loopback IPv4' => ['127.0.0.1'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- allow AuroraClient::ipIsValid to treat the IANA documentation address ranges as valid
- keep existing safeguards for private and loopback addresses through dedicated helpers
- add focused PHPUnit coverage for documentation and local IP validation behaviour

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/AuroraClient/AuroraClientIpValidationTest.php
- vendor/bin/phpstan analyse --memory-limit=512M *(fails: repository lacks Symfony testing dependencies, producing numerous class-not-found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa20dcbb08328821249b0eac9ea9f