### PR TITLE
Handle APCu fallback and improve bot detection

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -3,6 +3,7 @@
 namespace Sindla\Bundle\AuroraBundle\Utils\AuroraClient;
 
 use GeoIp2\Database\Reader;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraIP\AuroraIP;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraMatch\AuroraMatch;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
@@ -388,6 +389,12 @@ class AuroraClient
             $IP = $this->ip($IP);
         }
 
+        $ipString = trim((string) $IP);
+
+        if (!$this->ipIsValid($ipString)) {
+            return false;
+        }
+
         /**
          * @TODO: instead of gethostbyaddr, use (https://developers.google.com/search/docs/crawling-indexing/verifying-googlebot):
          *      https://developers.google.com/static/search/apis/ipranges/googlebot.json
@@ -396,11 +403,19 @@ class AuroraClient
          *      https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers-google.json
          */
 
-        $hostname = gethostbyaddr(trim($IP));
+        $hostname = gethostbyaddr($ipString);
 
         $AuroraMatch = new AuroraMatch();
 
-        return $AuroraMatch->matchAtLeastOneDomain($hostname, ['google.com', 'googlebot.com']);
+        if (is_string($hostname) && $hostname !== '' && $hostname !== $ipString) {
+            if ($AuroraMatch->matchAtLeastOneDomain($hostname, ['google.com', 'googlebot.com'])) {
+                return true;
+            }
+        }
+
+        $auroraIP = new AuroraIP();
+
+        return $auroraIP->isGoogle($ipString);
     }
 
     /**
@@ -422,12 +437,26 @@ class AuroraClient
          *      https://www.bing.com/toolbox/bingbot.json
          */
 
-        $hostname = gethostbyaddr(trim($IP));
+        $ipString = trim((string) $IP);
+
+        if (!$this->ipIsValid($ipString)) {
+            return false;
+        }
+
+        $hostname = gethostbyaddr($ipString);
 
         /** @var AuroraMatch $AuroraMatch */
         $AuroraMatch = new AuroraMatch();
 
-        return $AuroraMatch->matchAtLeastOneDomain($hostname, ['msn.com', 'bing.com']);
+        if (is_string($hostname) && $hostname !== '' && $hostname !== $ipString) {
+            if ($AuroraMatch->matchAtLeastOneDomain($hostname, ['msn.com', 'bing.com'])) {
+                return true;
+            }
+        }
+
+        $auroraIP = new AuroraIP();
+
+        return $auroraIP->isBing($ipString);
     }
 
     /**

--- a/src/Utils/PWA/PWA.php
+++ b/src/Utils/PWA/PWA.php
@@ -4,7 +4,10 @@ namespace Sindla\Bundle\AuroraBundle\Utils\PWA;
 
 use AllowDynamicProperties;
 use MatthiasMullie\Minify;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Exception\CacheException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
@@ -73,7 +76,7 @@ class PWA
      */
     public function manifestJSON(Request $request): JsonResponse
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCacheAdapter();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__ . sha1($request->getRequestUri())), function (ItemInterface $item) use ($request) {
 
@@ -161,7 +164,7 @@ class PWA
      */
     public function browserConfig(Request $request): Response
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCacheAdapter();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__ . sha1($request->getRequestUri())), function (ItemInterface $item) {
             $encoder       = new XmlEncoder();
@@ -340,7 +343,7 @@ class PWA
      */
     public function icon(Request $request): Response|BinaryFileResponse
     {
-        $cache = new ApcuAdapter('', ('prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1));
+        $cache = $this->createCacheAdapter();
 
         return $cache->get(sha1(__NAMESPACE__ . __CLASS__ . __METHOD__ . __LINE__ . sha1($request->getRequestUri())), function (ItemInterface $item) use ($request) {
             $iconPath = $this->container->getParameter('aurora.pwa.icons') . $request->getRequestUri();
@@ -379,5 +382,20 @@ class PWA
         $response->headers->set('Content-Length', filesize($iconPath));
         $response->headers->set('X-Backend-Hit', true);
         return $response;
+    }
+
+    private function createCacheAdapter(): AdapterInterface
+    {
+        $defaultLifetime = 'prod' == $this->container->getParameter('kernel.environment') ? (60 * 60 * 24) : 1;
+
+        if (ApcuAdapter::isSupported()) {
+            try {
+                return new ApcuAdapter('', $defaultLifetime);
+            } catch (CacheException) {
+                // APCu support declared itself unavailable, fall back to an in-memory cache.
+            }
+        }
+
+        return new ArrayAdapter($defaultLifetime);
     }
 }


### PR DESCRIPTION
## Summary
- add an adapter factory so PWA responses fall back to an in-memory cache when APCu is unavailable
- validate bot IPs against the existing CIDR lists when reverse DNS does not yield a trusted hostname

## Testing
- `KERNEL_CLASS=App\\Kernel APP_ENV=test php vendor/bin/phpunit --no-coverage -c vendor/sindla/aurora/phpunit.xml.dist vendor/sindla/aurora/tests/`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: numerous pre-existing missing-class errors in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa5ffe2ec83289d02750f4cb7bf27