### PR TITLE
Fix month interval detection in diffIsHigherThan

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -196,18 +196,22 @@ class AuroraChronos
                 return false;
             }
 
-            $monthsDiff = abs($this->monthsBetweenTwoDates($startDate, $endDate));
+            $monthsDiff = ($interval->y * 12) + $interval->m;
             $hasRemainder = $interval->d > 0
                 || $interval->h > 0
                 || $interval->i > 0
                 || $interval->s > 0
                 || $interval->f > 0;
 
-            return (
-                $monthsDiff > $intervalUnit
-                ||
-                ($monthsDiff === $intervalUnit && $hasRemainder)
-            );
+            if ($monthsDiff > $intervalUnit) {
+                return true;
+            }
+
+            if ($monthsDiff === $intervalUnit) {
+                return $hasRemainder;
+            }
+
+            return false;
         }
 
         if (self::TIME_UNIT_YEARS == $timeUnit) {

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -156,6 +156,20 @@ class AuroraChronosTest extends TestCase
                          'expected'     => true
                      ],
                      [
+                         'startDate'    => '2024-01-31 00:00:00',
+                         'endDate'      => '2024-02-28 00:00:00',
+                         'interval'     => 1,
+                         'intervalUnit' => AuroraChronos::TIME_UNIT_MONTHS,
+                         'expected'     => false
+                     ],
+                     [
+                         'startDate'    => '2024-01-31 00:00:00',
+                         'endDate'      => '2024-03-02 00:00:01',
+                         'interval'     => 1,
+                         'intervalUnit' => AuroraChronos::TIME_UNIT_MONTHS,
+                         'expected'     => true
+                     ],
+                     [
                          'startDate'    => '2024-02-01 00:00:00',
                          'endDate'      => '2024-01-01 00:00:00',
                          'interval'     => 1,


### PR DESCRIPTION
## Summary
- correct the month comparison logic in `AuroraChronos::diffIsHigherThan` to avoid treating partial months as full ones
- add regression tests covering month boundaries in `AuroraChronosTest`

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Utils/AuroraChronos/AuroraChronosTest.php


------
https://chatgpt.com/codex/tasks/task_e_68cfad5bd0e88328997457ff22d2fd37