### PR TITLE
Prevent AuroraCalendar from mutating mutable dates

### DIFF
--- a/src/Utils/AuroraCalendar/AuroraCalendar.php
+++ b/src/Utils/AuroraCalendar/AuroraCalendar.php
@@ -33,9 +33,10 @@ class AuroraCalendar
      */
     public function weekDaysFromPreviousMonthBeforeFirstDayOfTheMonth(\DateTimeInterface $date): int
     {
-        $date                 = $date->setDate($date->format('Y'), $date->format('m'), 1);
-        $firstDayWeekPosition = $date->format('N'); // 1 = monday, 7 = sunday
-        return (1 == $firstDayWeekPosition ? 0 : (int)$firstDayWeekPosition - 1);
+        $firstDayOfMonth      = \DateTimeImmutable::createFromInterface($date)->modify('first day of this month');
+        $firstDayWeekPosition = (int)$firstDayOfMonth->format('N'); // 1 = monday, 7 = sunday
+
+        return (DayOfWeek::MONDAY->value === $firstDayWeekPosition ? 0 : $firstDayWeekPosition - 1);
     }
 
     /**

--- a/tests/Utils/AuroraCalendar/AuroraCalendarMutationTest.php
+++ b/tests/Utils/AuroraCalendar/AuroraCalendarMutationTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCalendar;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraCalendar\AuroraCalendar;
+
+class AuroraCalendarMutationTest extends TestCase
+{
+    public function testWeekDaysFromPreviousMonthBeforeFirstDayDoesNotMutateDateTime(): void
+    {
+        $calendar = new AuroraCalendar();
+        $date     = new \DateTime('2024-09-15 10:20:30', new \DateTimeZone('Europe/Bucharest'));
+        $original = $date->format('c');
+
+        $calendar->weekDaysFromPreviousMonthBeforeFirstDayOfTheMonth($date);
+
+        self::assertSame($original, $date->format('c'));
+    }
+
+    public function testWeekDaysFromPreviousMonthBeforeFirstDayMatchesImmutableResult(): void
+    {
+        $calendar  = new AuroraCalendar();
+        $mutable   = new \DateTime('2024-09-15 10:20:30', new \DateTimeZone('Europe/Bucharest'));
+        $immutable = new \DateTimeImmutable('2024-09-15 10:20:30', new \DateTimeZone('Europe/Bucharest'));
+
+        $mutableResult   = $calendar->weekDaysFromPreviousMonthBeforeFirstDayOfTheMonth($mutable);
+        $immutableResult = $calendar->weekDaysFromPreviousMonthBeforeFirstDayOfTheMonth($immutable);
+
+        self::assertSame($immutableResult, $mutableResult);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `AuroraCalendar::weekDaysFromPreviousMonthBeforeFirstDayOfTheMonth` works on a cloned immutable copy
- keep the original `\DateTime` instances unchanged while preserving existing behaviour
- add regression tests covering mutable vs. immutable usage

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Utils/AuroraCalendar/AuroraCalendarMutationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cfb133bc14832885229f4c154a696b