### PR TITLE
Fix diffIsHigherThan remainder handling

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -160,34 +160,67 @@ class AuroraChronos
 
         // Minutes
         if (self::TIME_UNIT_MINUTES == $timeUnit) {
+            $minutes = $this->minutesBetweenTwoDates($startDate, $endDate);
+
+            if ($minutes > $intervalUnit) {
+                return true;
+            }
+
             return (
-                $this->minutesBetweenTwoDates($startDate, $endDate) > $intervalUnit
-                ||
-                ($this->minutesBetweenTwoDates($startDate, $endDate) == $intervalUnit && $interval->format('%r%s') > 0)
+                $minutes === $intervalUnit
+                && 0 === $interval->invert
+                && ($interval->s > 0 || $interval->f > 0)
             );
         }
 
         if (self::TIME_UNIT_HOURS == $timeUnit) {
+            $hours = $this->hoursBetweenTwoDates($startDate, $endDate);
+
+            if ($hours > $intervalUnit) {
+                return true;
+            }
+
             return (
-                $this->hoursBetweenTwoDates($startDate, $endDate) > $intervalUnit
-                ||
-                ($this->hoursBetweenTwoDates($startDate, $endDate) == $intervalUnit && $interval->format('%r%s') > 0)
+                $hours === $intervalUnit
+                && 0 === $interval->invert
+                && ($interval->i > 0 || $interval->s > 0 || $interval->f > 0)
             );
         }
 
         if (self::TIME_UNIT_DAYS == $timeUnit) {
+            $days = (int) $this->daysBetweenTwoDates($startDate, $endDate);
+
+            if ($days > $intervalUnit) {
+                return true;
+            }
+
             return (
-                $this->daysBetweenTwoDates($startDate, $endDate) > $intervalUnit
-                ||
-                ($this->daysBetweenTwoDates($startDate, $endDate) == $intervalUnit && $interval->format('%r%s') > 0)
+                $days === $intervalUnit
+                && 0 === $interval->invert
+                && ($interval->h > 0 || $interval->i > 0 || $interval->s > 0 || $interval->f > 0)
             );
         }
 
         if (self::TIME_UNIT_WEEKS == $timeUnit) {
+            $totalDays = (int) $this->daysBetweenTwoDates($startDate, $endDate);
+            $weeks     = intdiv($totalDays, 7);
+
+            if ($weeks > $intervalUnit) {
+                return true;
+            }
+
+            $remainingDays = abs($totalDays % 7);
+
             return (
-                ($this->daysBetweenTwoDates($startDate, $endDate) / 7) > $intervalUnit
-                ||
-                (($this->daysBetweenTwoDates($startDate, $endDate) / 7) == $intervalUnit && $interval->format('%r%s') > 0)
+                $weeks === $intervalUnit
+                && 0 === $interval->invert
+                && (
+                    $remainingDays > 0
+                    || $interval->h > 0
+                    || $interval->i > 0
+                    || $interval->s > 0
+                    || $interval->f > 0
+                )
             );
         }
 

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -122,6 +122,27 @@ class AuroraChronosTest extends TestCase
                      ],
                      [
                          'startDate'    => '2010-01-01 11:12:13',
+                         'endDate'      => '2010-01-01 12:13:13',
+                         'interval'     => 1,
+                         'intervalUnit' => AuroraChronos::TIME_UNIT_HOURS,
+                         'expected'     => true
+                     ],
+                     [
+                         'startDate'    => '2010-01-01 11:12:13',
+                         'endDate'      => '2010-01-02 11:12:13',
+                         'interval'     => 1,
+                         'intervalUnit' => AuroraChronos::TIME_UNIT_DAYS,
+                         'expected'     => false
+                     ],
+                     [
+                         'startDate'    => '2010-01-01 11:12:13',
+                         'endDate'      => '2010-01-02 12:12:13',
+                         'interval'     => 1,
+                         'intervalUnit' => AuroraChronos::TIME_UNIT_DAYS,
+                         'expected'     => true
+                     ],
+                     [
+                         'startDate'    => '2010-01-01 11:12:13',
                          'endDate'      => '2010-01-08 11:12:13',
                          'interval'     => 1,
                          'intervalUnit' => AuroraChronos::TIME_UNIT_WEEKS,
@@ -130,6 +151,13 @@ class AuroraChronosTest extends TestCase
                      [
                          'startDate'    => '2010-01-01 11:12:13',
                          'endDate'      => '2010-01-08 11:12:14',
+                         'interval'     => 1,
+                         'intervalUnit' => AuroraChronos::TIME_UNIT_WEEKS,
+                         'expected'     => true
+                     ],
+                     [
+                         'startDate'    => '2010-01-01 11:12:13',
+                         'endDate'      => '2010-01-08 12:12:13',
                          'interval'     => 1,
                          'intervalUnit' => AuroraChronos::TIME_UNIT_WEEKS,
                          'expected'     => true


### PR DESCRIPTION
## Summary
- ensure `AuroraChronos::diffIsHigherThan()` treats leftover minutes, hours, days, and weeks as exceeding the threshold
- add PHPUnit cases covering partial hours, days, and weeks to prevent regressions

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php vendor/bin/phpunit --no-coverage -c vendor/sindla/aurora/phpunit.xml.dist vendor/sindla/aurora/tests/`
- `KERNEL_CLASS=App\Kernel APP_ENV=test php -d memory_limit=1G vendor/bin/phpstan analyse -l 6 vendor/sindla/aurora/src`


------
https://chatgpt.com/codex/tasks/task_e_68cfc0681fec83288e5a45a131fb119c