### PR TITLE
Fix Accept-Language duplicate locale handling

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -366,7 +366,9 @@ class AuroraClient
                     }
                 }
 
-                $prefLanguages[$locale] = $quality;
+                if (!isset($prefLanguages[$locale]) || $quality > $prefLanguages[$locale]) {
+                    $prefLanguages[$locale] = $quality;
+                }
             }
 
             arsort($prefLanguages);

--- a/tests/Utils/AuroraClient/AuroraClientTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientTest.php
@@ -83,6 +83,22 @@ class AuroraClientTest extends KernelTestCase
         unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
     }
 
+    public function testPreferredLanguagesKeepsHighestQualityForDuplicateLocales(): void
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.8,en-US;q=0.4';
+        $client                          = new AuroraClient($this->containerTest);
+
+        $this->assertSame(
+            [
+                'en-US' => 1.0,
+                'en'    => 0.8,
+            ],
+            $client->preferredLanguages()
+        );
+
+        unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+    }
+
     public function __SKIP__testIP2CountryCode()
     {
         $Client = new AuroraClient($this->containerTest);


### PR DESCRIPTION
## Summary
- ensure AuroraClient::preferredLanguages keeps the highest q-value per locale when parsing Accept-Language headers
- add a regression test covering duplicate locale entries to confirm parsing behaviour

## Testing
- `KERNEL_CLASS=App\\Kernel APP_ENV=test php vendor/bin/phpunit --no-coverage -c vendor/sindla/aurora/phpunit.xml.dist vendor/sindla/aurora/tests/`
- `KERNEL_CLASS=App\\Kernel APP_ENV=test php -d memory_limit=1G vendor/bin/phpstan analyse -l 6 vendor/sindla/aurora/src` *(fails: existing phpstan issues in project)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc434e64483288d231660159365ef