### PR TITLE
Fix SHA-256 unsigned conversion and add coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "sort-packages": true
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^8.3",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^12.3"
     }

--- a/src/Utils/AuroraCryptor/AuroraCryptor.php
+++ b/src/Utils/AuroraCryptor/AuroraCryptor.php
@@ -180,6 +180,18 @@ class AuroraCryptor
      */
     function sha256To32BitUnsigned(string $data): string
     {
-        return (string) ((int) $this->sha256To32Bit($data) % 2147483647);
+        $hash32Hex = substr(hash('sha256', $data), 0, 8);
+
+        if (function_exists('gmp_init')) {
+            return gmp_strval(gmp_init($hash32Hex, 16));
+        }
+
+        $decimal = hexdec($hash32Hex);
+
+        if (is_float($decimal)) {
+            return sprintf('%.0f', $decimal);
+        }
+
+        return (string) $decimal;
     }
 }

--- a/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
+++ b/tests/Utils/AuroraCryptor/AuroraCryptorTest.php
@@ -5,6 +5,7 @@ namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCryptor;
 
 use InvalidArgumentException;
 use RuntimeException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraCryptor\AuroraCryptor;
 
@@ -85,15 +86,33 @@ class AuroraCryptorTest extends TestCase
         $cryptor->setEncryptionKey($key)->decrypt($tamperedPayload);
     }
 
-    public function testSha256To32BitUnsigned(): void
+    #[DataProvider('dataSha256To32BitUnsigned')]
+    public function testSha256To32BitUnsigned(string $input, string $expected, bool $exceedsSignedLimit): void
     {
         $cryptor = new AuroraCryptor();
-        $result  = $cryptor->sha256To32BitUnsigned('example');
+        $result  = $cryptor->sha256To32BitUnsigned($input);
 
-        $this->assertIsString($result);
-        $value = (int) $result;
-        $this->assertGreaterThanOrEqual(0, $value);
-        $this->assertLessThanOrEqual(2147483647, $value);
+        $this->assertSame($expected, $result);
+        $this->assertSame($expected, $cryptor->sha256To32Bit($input));
+        $this->assertTrue(ctype_digit($result));
+
+        $numericResult = (float) $result;
+        $this->assertGreaterThanOrEqual(0.0, $numericResult);
+        $this->assertLessThanOrEqual(4294967295.0, $numericResult);
+
+        if ($exceedsSignedLimit) {
+            $this->assertGreaterThan(2147483647.0, $numericResult);
+        } else {
+            $this->assertLessThanOrEqual(2147483647.0, $numericResult);
+        }
+    }
+
+    public static function dataSha256To32BitUnsigned(): array
+    {
+        return [
+            ['example', '1356355808', false],
+            ['test', '2676412545', true],
+        ];
     }
 
     public function testSetCipherRegeneratesInitializationVector(): void


### PR DESCRIPTION
## Summary
- ensure `AuroraCryptor::sha256To32BitUnsigned()` keeps the full 32-bit unsigned range by converting the hash fragment with GMP or a safe fallback
- extend `AuroraCryptorTest` with a data provider that verifies the unsigned SHA-256 conversion for values inside and outside the signed 32-bit range
- add `dama/doctrine-test-bundle` as a dev dependency so the configured PHPUnit extension is available during tests

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Utils/AuroraCryptor/AuroraCryptorTest.php
- ./vendor/bin/phpstan analyse -l 6 src/Utils/AuroraCryptor/AuroraCryptor.php --memory-limit=1G

------
https://chatgpt.com/codex/tasks/task_e_68cfcb6ec2948328a018c79a57f3e1b0