### PR TITLE
Validate CIDR prefixes before matching

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -288,11 +288,14 @@ class AuroraClient
 
         [$subnet, $prefixLength] = explode('/', $cidr, 2);
 
-        if ($subnet === '') {
+        $subnet       = trim($subnet);
+        $prefixLength = trim($prefixLength);
+
+        if ($subnet === '' || $prefixLength === '' || !ctype_digit($prefixLength)) {
             return false;
         }
 
-        $prefixLength = (int) trim($prefixLength);
+        $prefixLength = (int) $prefixLength;
         $ipBinary     = inet_pton($ip);
         $subnetBinary = inet_pton($subnet);
 

--- a/tests/Utils/AuroraClient/AuroraClientTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientTest.php
@@ -99,6 +99,29 @@ class AuroraClientTest extends KernelTestCase
         unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
     }
 
+    public function testIpMatchesCidrRejectsInvalidPrefixes(): void
+    {
+        $client = new AuroraClient($this->containerTest);
+
+        $reflectionMethod = new \ReflectionMethod($client, 'ipMatchesCidr');
+        $reflectionMethod->setAccessible(true);
+
+        self::assertFalse(
+            $reflectionMethod->invoke($client, '198.51.100.23', '198.51.100.0/abc'),
+            'CIDR masks containing non-numeric characters must be rejected.'
+        );
+
+        self::assertFalse(
+            $reflectionMethod->invoke($client, '2001:db8::1', '2001:db8::/64bad'),
+            'IPv6 CIDR masks containing non-numeric characters must be rejected.'
+        );
+
+        self::assertTrue(
+            $reflectionMethod->invoke($client, '198.51.100.23', ' 198.51.100.0/24 '),
+            'Valid CIDR masks with surrounding whitespace should still be accepted.'
+        );
+    }
+
     public function __SKIP__testIP2CountryCode()
     {
         $Client = new AuroraClient($this->containerTest);


### PR DESCRIPTION
## Summary
- ensure AuroraClient::ipMatchesCidr trims CIDR components and rejects non-numeric prefixes before matching
- cover the CIDR validation behaviour with a dedicated unit test that also confirms whitespace handling

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php vendor/bin/phpunit --no-coverage -c vendor/sindla/aurora/phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraClient/AuroraClientTest.php`
- `KERNEL_CLASS=App\Kernel APP_ENV=test php -d memory_limit=512M vendor/bin/phpstan analyse -l 6 vendor/sindla/aurora/src` *(fails: existing 443 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe3d2bcd08328a94446d62e5a99dc