### PR TITLE
Fix BlackHole API bearer header and cover with tests

### DIFF
--- a/src/EventSubscriber/BlackHoleSubscriber.php
+++ b/src/EventSubscriber/BlackHoleSubscriber.php
@@ -7,16 +7,17 @@ namespace Sindla\Bundle\AuroraBundle\EventSubscriber;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
 use Sindla\Bundle\AuroraBundle\Utils\Strink\Strink;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 readonly class BlackHoleSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private AuroraClient $auroraClient
+        private AuroraClient $auroraClient,
+        private HttpClientInterface $httpClient
     )
     {
     }
@@ -46,7 +47,6 @@ readonly class BlackHoleSubscriber implements EventSubscriberInterface
             ) {
                 $exception = $event->getThrowable();
                 if ($exception instanceof NotFoundHttpException) {
-                    $client = HttpClient::create();
                     try {
                         $payload = [
                             'method'    => $request->getMethod(),
@@ -64,7 +64,7 @@ readonly class BlackHoleSubscriber implements EventSubscriberInterface
                             'headers'   => $request->headers->all(),
                         ];
 
-                        $client->request(
+                        $this->httpClient->request(
                             'POST',
                             new Strink()->string(sprintf(
                                 '%s/%s/%s',
@@ -75,7 +75,7 @@ readonly class BlackHoleSubscriber implements EventSubscriberInterface
                             [
                                 'headers' => [
                                     'Content-Type'  => 'application/json',
-                                    'Authorization' => 'Bearer ' . $_ENV['BLACK_HOLE_API_VERSION']
+                                    'Authorization' => 'Bearer ' . $_ENV['BLACK_HOLE_API_BEARER']
                                 ],
                                 'json'    => $payload,
                             ]

--- a/tests/EventSubscriber/BlackHoleSubscriberTest.php
+++ b/tests/EventSubscriber/BlackHoleSubscriberTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\EventSubscriber\BlackHoleSubscriber;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class BlackHoleSubscriberTest extends TestCase
+{
+    public function testUsesConfiguredBearerTokenWhenForwardingRequest(): void
+    {
+        $previousEnv = [];
+        foreach ([
+            'BLACK_HOLE_API_ENABLED',
+            'BLACK_HOLE_API_URL',
+            'BLACK_HOLE_API_VERSION',
+            'BLACK_HOLE_API_ENDPOINT',
+            'BLACK_HOLE_API_BEARER',
+        ] as $key) {
+            $previousEnv[$key] = $_ENV[$key] ?? null;
+        }
+
+        $_ENV['BLACK_HOLE_API_ENABLED'] = 'true';
+        $_ENV['BLACK_HOLE_API_URL'] = 'https://blackhole.example';
+        $_ENV['BLACK_HOLE_API_VERSION'] = 'v1';
+        $_ENV['BLACK_HOLE_API_ENDPOINT'] = 'events';
+        $_ENV['BLACK_HOLE_API_BEARER'] = 'test-bearer';
+
+        $capturedOptions = null;
+        $mockClient = new MockHttpClient(
+            function (string $method, string $url, array $options) use (&$capturedOptions): MockResponse {
+                $capturedOptions = [
+                    'method'  => $method,
+                    'url'     => $url,
+                    'options' => $options,
+                ];
+
+                return new MockResponse('', ['http_code' => 200]);
+            }
+        );
+
+        $auroraClient = $this->createMock(AuroraClient::class);
+        $auroraClient
+            ->expects($this->exactly(2))
+            ->method('ip')
+            ->willReturn('203.0.113.10');
+
+        $subscriber = new BlackHoleSubscriber($auroraClient, $mockClient);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = Request::create('https://app.example/resource');
+        $request->server->set('SERVER_ADDR', '198.51.100.20');
+        $event = new ExceptionEvent(
+            $kernel,
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new NotFoundHttpException()
+        );
+
+        try {
+            $subscriber->onKernelException($event);
+        } finally {
+            foreach ($previousEnv as $key => $value) {
+                if (null === $value) {
+                    unset($_ENV[$key]);
+                } else {
+                    $_ENV[$key] = $value;
+                }
+            }
+        }
+
+        $this->assertNotNull($capturedOptions, 'The HTTP client was not invoked.');
+        $this->assertSame('POST', $capturedOptions['method']);
+        $this->assertArrayHasKey('normalized_headers', $capturedOptions['options']);
+        $this->assertArrayHasKey('authorization', $capturedOptions['options']['normalized_headers']);
+        $this->assertContains(
+            'Authorization: Bearer test-bearer',
+            $capturedOptions['options']['normalized_headers']['authorization']
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,12 +2,18 @@
 
 use Symfony\Component\Dotenv\Dotenv;
 
-if (is_file(dirname(__DIR__) . '/vendor/autoload.php')) {
+if (defined('PHPUNIT_COMPOSER_INSTALL') && is_file(PHPUNIT_COMPOSER_INSTALL)) {
+    require PHPUNIT_COMPOSER_INSTALL;
+} else if (is_file(dirname(__DIR__) . '/vendor/autoload.php')) {
     require dirname(__DIR__) . '/vendor/autoload.php';
+} else if (is_file(dirname(__DIR__, 3) . '/autoload.php')) {
+    require dirname(__DIR__, 3) . '/autoload.php';
 } else if (is_file(dirname(__DIR__) . '/../../../autoload.php')) {
     require dirname(__DIR__) . '/../../../autoload.php';
 } else if (is_file(__DIR__ . '/../vendor/autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
+} else if (is_string(getcwd()) && is_file(getcwd() . '/vendor/autoload.php')) {
+    require getcwd() . '/vendor/autoload.php';
 } else {
     throw new \RuntimeException('Could not find the autoload.php file. Please run "composer install".');
 }


### PR DESCRIPTION
## Summary
- inject `HttpClientInterface` into `BlackHoleSubscriber` and send the configured bearer token when notifying the Black Hole API
- harden the bundle test bootstrap to locate Composer's autoload file when the bundle is installed as a dependency
- add a focused unit test that exercises the subscriber and asserts the Authorization header uses the configured bearer token

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php vendor/bin/phpunit --no-coverage -c vendor/sindla/aurora/phpunit.xml.dist vendor/sindla/aurora/tests/`
- `APP_ENV=test php -d memory_limit=512M vendor/bin/phpstan analyse -l 6 vendor/sindla/aurora/src` *(fails: existing project issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cffbd456e08328abd609160cd3d6a7