### PR TITLE
Fix filterAge to support DateTimeInterface

### DIFF
--- a/src/Utils/Twig/UtilityExtension.php
+++ b/src/Utils/Twig/UtilityExtension.php
@@ -50,7 +50,7 @@ class UtilityExtension extends AbstractExtension
         ];
     }
 
-    public function filterAge(\DateTime $date): int
+    public function filterAge(\DateTimeInterface $date): int
     {
         $referenceDateTimeObject = new \DateTime();
 

--- a/tests/Twig/AbstractExtensionStub.php
+++ b/tests/Twig/AbstractExtensionStub.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Twig;
+
+abstract class AbstractExtensionStub
+{
+}

--- a/tests/Utils/Twig/UtilityExtensionTest.php
+++ b/tests/Utils/Twig/UtilityExtensionTest.php
@@ -26,7 +26,7 @@ class UtilityExtensionTest extends TestCase
     }
 
     #[DataProvider('dataFilterAge')]
-    public function testFilterAge(\DateTime $given, int $expected): void
+    public function testFilterAge(\DateTimeInterface $given, int $expected): void
     {
         $extension = new UtilityExtension(
             new Container(),
@@ -52,14 +52,21 @@ class UtilityExtensionTest extends TestCase
         foreach (range(1, 12) as $month) {
             foreach ([1, 10, 20, 28] as $day) {
                 $year = $years[$index++];
-                $date = new \DateTime(sprintf('%04d-%02d-%02d', $year, $month, $day));
-                $data[] = [$date, $reference->diff($date)->y];
+                $dateString = sprintf('%04d-%02d-%02d', $year, $month, $day);
+                $date       = new \DateTime($dateString);
+                $expected   = $reference->diff($date)->y;
+
+                $data[] = [$date, $expected];
+                $data[] = [new \DateTimeImmutable($dateString), $expected];
             }
         }
 
         foreach (['2000-02-29', '2024-02-29'] as $extra) {
-            $date   = new \DateTime($extra);
-            $data[] = [$date, $reference->diff($date)->y];
+            $date     = new \DateTime($extra);
+            $expected = $reference->diff($date)->y;
+
+            $data[] = [$date, $expected];
+            $data[] = [new \DateTimeImmutable($extra), $expected];
         }
 
         return $data;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,14 @@ if (!class_exists(\Symfony\Bundle\FrameworkBundle\Test\KernelTestCase::class)) {
     require __DIR__ . '/SymfonyKernelTestCaseStub.php';
 }
 
+if (!class_exists(\Twig\Extension\AbstractExtension::class)) {
+    require_once __DIR__ . '/Twig/AbstractExtensionStub.php';
+    class_alias(
+        \Sindla\Bundle\AuroraBundle\Tests\Twig\AbstractExtensionStub::class,
+        \Twig\Extension\AbstractExtension::class
+    );
+}
+
 if (file_exists(dirname(__DIR__) . '/config/bootstrap.php')) {
     require dirname(__DIR__) . '/config/bootstrap.php';
 } else if (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
## Summary
- update the `aurora.age` filter to accept any `DateTimeInterface` implementation
- expand the UtilityExtension test data to include `DateTimeImmutable` values and add a Twig AbstractExtension stub for tests

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist --no-coverage --testsuite "Project Test Suite" --filter UtilityExtensionTest

------
https://chatgpt.com/codex/tasks/task_e_68d001076df0832895915a1be27f1acc