### PR TITLE
Clamp AuroraChronos week ranges to requested interval

### DIFF
--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -401,11 +401,21 @@ class AuroraChronos
             $weekYear = sprintf('%d-%02d', $year, $week);
 
             if (!isset($weeks[$weekYear])) {
+                $weekStartDate = ('1' === $date->format('N')) ? $date : $date->modify('previous Monday');
+                if ($weekStartDate < $start) {
+                    $weekStartDate = $start;
+                }
+
+                $weekEndDate = ('7' === $date->format('N')) ? $date : $date->modify('next Sunday');
+                if ($weekEndDate > $end) {
+                    $weekEndDate = $end;
+                }
+
                 $weeks[$weekYear] = [
                     'week'           => $week,
                     'year'           => $year,
-                    'firstDayOfWeek' => (1 == (intval($date->format('N'))) ? $date->format('Y-m-d') : $date->modify('previous Monday')->format('Y-m-d')),
-                    'lastDayOfWeek'  => (7 == (intval($date->format('N'))) ? $date->format('Y-m-d') : $date->modify('next Sunday')->format('Y-m-d')),
+                    'firstDayOfWeek' => $weekStartDate->format('Y-m-d'),
+                    'lastDayOfWeek'  => $weekEndDate->format('Y-m-d'),
                 ];
             }
         }

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -398,6 +398,43 @@ class AuroraChronosTest extends TestCase
         ];
     }
 
+    public function testGetUniqueWeeksInRangeClampsStartAndEndOfFirstWeek(): void
+    {
+        $chronos = new AuroraChronos();
+
+        $start = new \DateTimeImmutable('2024-01-31');
+        $end   = new \DateTimeImmutable('2024-02-01');
+
+        $weeks = $chronos->getUniqueWeeksInRange($start, $end);
+
+        self::assertCount(1, $weeks);
+        self::assertSame('2024-01-31', $weeks[0]['firstDayOfWeek']);
+        self::assertSame('2024-02-01', $weeks[0]['lastDayOfWeek']);
+    }
+
+    public function testGetUniqueWeeksInRangeKeepsFinalWeekWithinBounds(): void
+    {
+        $chronos = new AuroraChronos();
+
+        $start = new \DateTimeImmutable('2024-03-01');
+        $end   = new \DateTimeImmutable('2024-03-12');
+
+        $weeks = $chronos->getUniqueWeeksInRange($start, $end);
+
+        self::assertNotEmpty($weeks);
+        self::assertSame('2024-03-01', $weeks[0]['firstDayOfWeek']);
+
+        $lastWeek = end($weeks);
+
+        self::assertIsArray($lastWeek);
+        self::assertSame('2024-03-12', $lastWeek['lastDayOfWeek']);
+
+        foreach ($weeks as $week) {
+            self::assertGreaterThanOrEqual($start->format('Y-m-d'), $week['firstDayOfWeek']);
+            self::assertLessThanOrEqual($end->format('Y-m-d'), $week['lastDayOfWeek']);
+        }
+    }
+
     public function testSeconds2HMS(): void
     {
         $Chronos = new AuroraChronos();


### PR DESCRIPTION
## Summary
- clamp the computed week boundaries in `AuroraChronos::getUniqueWeeksInRange()` so that the reported range never exceeds the requested start and end dates
- add regression tests that reproduce the off-by-range behaviour and verify the new boundary clamping logic

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php /workspace/Aurora-installed/vendor/bin/phpunit --no-coverage -c /workspace/Aurora-installed/vendor/sindla/aurora/phpunit.xml.dist /workspace/Aurora-installed/vendor/sindla/aurora/tests/`
- `KERNEL_CLASS=App\Kernel APP_ENV=test php -d memory_limit=1G /workspace/Aurora-installed/vendor/bin/phpstan analyse -l 6 /workspace/Aurora-installed/vendor/sindla/aurora/src` *(fails: long-standing typehint issues in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68d01574698483289bcd32b76d3e9c4c