### PR TITLE
Fix Strink camelCase to snake_case conversion for uppercase sequences

### DIFF
--- a/src/Utils/Strink/Strink.php
+++ b/src/Utils/Strink/Strink.php
@@ -278,9 +278,30 @@ class Strink
      */
     public function camelCaseToSnakeCase(): self
     {
-        $encoding     = $this->detectEncoding();
-        $this->string = preg_replace('/(?<!^)\p{Lu}/u', '_$0', $this->string);
+        $encoding = $this->detectEncoding();
+
+        $converted = preg_replace(
+            '/(?<=\p{Lu})(\p{Lu})(?=\p{Ll})/u',
+            '_$1',
+            $this->string
+        );
+
+        if ($converted !== null) {
+            $this->string = $converted;
+        }
+
+        $converted = preg_replace(
+            '/(?<=\p{Ll}|\p{Nd})(\p{Lu})/u',
+            '_$1',
+            $this->string
+        );
+
+        if ($converted !== null) {
+            $this->string = $converted;
+        }
+
         $this->string = mb_strtolower($this->string, $encoding);
+
         return $this;
     }
 

--- a/tests/Utils/Strink/StrinkTest.php
+++ b/tests/Utils/Strink/StrinkTest.php
@@ -44,6 +44,16 @@ class StrinkTest extends TestCase
             }
         }
 
+        foreach ([
+                     'xml_http_request' => ['XMLHttpRequest', 'XmlHTTPRequest'],
+                     'api_response'     => ['APIResponse'],
+                     'json_rpc'         => ['JsonRPC']
+                 ] as $expected => $givens) {
+            foreach ($givens as $given) {
+                $this->assertEquals($expected, $Strink->string($given)->camelCaseToSnakeCase());
+            }
+        }
+
         // UTF-8 support
         $this->assertEquals('denumire_șarpe', $Strink->string('DenumireȘarpe')->camelCaseToSnakeCase());
     }


### PR DESCRIPTION
## Summary
- improve Strink::camelCaseToSnakeCase to correctly separate consecutive uppercase segments before lowercasing
- extend StrinkTest::testCamelCaseToSnakeCase with cases covering consecutive-uppercase names

## Testing
- KERNEL_CLASS=App\\Kernel APP_ENV=test php /workspace/Aurora-installed/vendor/bin/phpunit --no-coverage -c /workspace/Aurora-installed/vendor/sindla/aurora/phpunit.xml.dist /workspace/Aurora-installed/vendor/sindla/aurora/tests/Utils/Strink/StrinkTest.php
- KERNEL_CLASS=App\\Kernel APP_ENV=test php /workspace/Aurora-installed/vendor/bin/phpunit --no-coverage -c /workspace/Aurora-installed/vendor/sindla/aurora/phpunit.xml.dist /workspace/Aurora-installed/vendor/sindla/aurora/tests/
- KERNEL_CLASS=App\\Kernel APP_ENV=test php -d memory_limit=512M /workspace/Aurora-installed/vendor/bin/phpstan analyse -l 6 /workspace/Aurora-installed/vendor/sindla/aurora/src *(fails: pre-existing PHPStan errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d01d013408832892bbc4eb9c475fcf