### PR TITLE
Fix statements badge width overflow

### DIFF
--- a/src/Utils/AuroraPHPUnitCodeCoverageBadge/AuroraPHPUnitCodeCoverageBadge.php
+++ b/src/Utils/AuroraPHPUnitCodeCoverageBadge/AuroraPHPUnitCodeCoverageBadge.php
@@ -158,8 +158,9 @@ SVG;
 
     private function __statementsSVG(): string
     {
-        $width     = 160;
-        $leftBlock = 75;
+        $width           = 160;
+        $leftBlock       = 75;
+        $rightBlockWidth = $width - $leftBlock;
 
         return <<<SVG
 <?xml version="1.0" encoding="UTF-8"?>
@@ -173,7 +174,7 @@ SVG;
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h{$leftBlock}v20H0z"/>
-        <path fill="{{ color }}" d="M{$leftBlock} 0h{$width}v20H{$leftBlock}z"/>
+        <path fill="{{ color }}" d="M{$leftBlock} 0h{$rightBlockWidth}v20H{$leftBlock}z"/>
         <path fill="url(#b)" d="M0 0h{$width}v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">

--- a/tests/Utils/AuroraPHPUnitCodeCoverageBadge/AuroraPHPUnitCodeCoverageBadgeTest.php
+++ b/tests/Utils/AuroraPHPUnitCodeCoverageBadge/AuroraPHPUnitCodeCoverageBadgeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraPHPUnitCodeCoverageBadge;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraPHPUnitCodeCoverageBadge\AuroraPHPUnitCodeCoverageBadge;
+
+class AuroraPHPUnitCodeCoverageBadgeTest extends TestCase
+{
+    public function testStatementsBadgeUsesCorrectRightBlockWidth(): void
+    {
+        $badge = new AuroraPHPUnitCodeCoverageBadge();
+
+        $tempDirectory = sys_get_temp_dir() . '/aurora_badge_' . uniqid('', true);
+        self::assertTrue(mkdir($tempDirectory));
+
+        $cloverFilePath     = $tempDirectory . '/clover.xml';
+        $coverageSvgPath    = $tempDirectory . '/coverage.svg';
+        $statementsSvgPath  = $tempDirectory . '/statements.svg';
+
+        $cloverXml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage>
+    <project>
+        <metrics elements="10" coveredelements="6"/>
+        <file name="Sample.php">
+            <metrics statements="5" coveredstatements="3"/>
+        </file>
+    </project>
+</coverage>
+XML;
+
+        file_put_contents($cloverFilePath, $cloverXml);
+
+        try {
+            $badge->generateCoverageBadges($cloverFilePath, $coverageSvgPath, $statementsSvgPath);
+
+            $statementsSvg = file_get_contents($statementsSvgPath);
+            self::assertIsString($statementsSvg);
+            self::assertStringContainsString('M75 0h85v20H75z', $statementsSvg);
+        } finally {
+            @unlink($cloverFilePath);
+            @unlink($coverageSvgPath);
+            @unlink($statementsSvgPath);
+            @rmdir($tempDirectory);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- correct the statements coverage badge geometry so the right-hand segment is constrained to the badge width
- add a regression test that verifies the generated statements badge uses the expected path dimensions

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php /workspace/Aurora-installed/vendor/bin/phpunit --no-coverage -c /workspace/Aurora-installed/vendor/sindla/aurora/phpunit.xml.dist /workspace/Aurora-installed/vendor/sindla/aurora/tests/`
- `KERNEL_CLASS=App\Kernel APP_ENV=test php /workspace/Aurora-installed/vendor/bin/phpstan analyse -l 6 /workspace/Aurora-installed/vendor/sindla/aurora//src --memory-limit=1G` *(fails: existing static analysis issues in vendor code)*

------
https://chatgpt.com/codex/tasks/task_e_68d036def54083288699818e90d64aff