### PR TITLE
Fix domain matching for paths without scheme

### DIFF
--- a/src/Utils/AuroraMatch/AuroraMatch.php
+++ b/src/Utils/AuroraMatch/AuroraMatch.php
@@ -12,6 +12,11 @@ class AuroraMatch
                 $needle = $parsedNeedle['host'];
             } elseif (!isset($parsedNeedle['scheme']) && isset($parsedNeedle['path'])) {
                 $needle = $parsedNeedle['path'];
+
+                $fallbackNeedle = parse_url('http://' . ltrim($needle, '/'));
+                if (false !== $fallbackNeedle && isset($fallbackNeedle['host'])) {
+                    $needle = $fallbackNeedle['host'];
+                }
             }
         }
 
@@ -21,6 +26,11 @@ class AuroraMatch
                 $domain = $parsedDomain['host'];
             } elseif (!isset($parsedDomain['scheme']) && isset($parsedDomain['path'])) {
                 $domain = $parsedDomain['path'];
+
+                $fallbackDomain = parse_url('http://' . ltrim($domain, '/'));
+                if (false !== $fallbackDomain && isset($fallbackDomain['host'])) {
+                    $domain = $fallbackDomain['host'];
+                }
             }
         }
 

--- a/tests/Utils/AuroraMatch/AuroraMatchTest.php
+++ b/tests/Utils/AuroraMatch/AuroraMatchTest.php
@@ -82,6 +82,16 @@ class AuroraMatchTest extends TestCase
                 'expected' => true,
             ],
             [
+                'needle'   => 'www.sindla.com/some/path',
+                'domain'   => 'sindla.com',
+                'expected' => true,
+            ],
+            [
+                'needle'   => 'sindla.com/another/path?foo=bar',
+                'domain'   => 'sindla.com',
+                'expected' => true,
+            ],
+            [
                 'needle'   => 'sindla.com:8080',
                 'domain'   => 'sindla.com',
                 'expected' => true,


### PR DESCRIPTION
## Summary
- ensure `AuroraMatch::matchDomain` extracts the host when URLs lack a scheme but include a path segment
- add regression cases covering bare domains with paths to the AuroraMatch test suite

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php /workspace/Aurora-installed/vendor/bin/phpunit --no-coverage -c /workspace/Aurora-installed/vendor/sindla/aurora/phpunit.xml.dist /workspace/Aurora-installed/vendor/sindla/aurora/tests/`
- `KERNEL_CLASS=App\Kernel APP_ENV=test php -d memory_limit=1G /workspace/Aurora-installed/vendor/bin/phpstan analyse -c /workspace/Aurora-installed/vendor/sindla/aurora/phpstan.neon /workspace/Aurora-installed/vendor/sindla/aurora//src` *(fails: upstream code triggers fatal errors such as HtmlFormatter::format signature mismatch and duplicate trait declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68d03a57152c8328a1f6b744e4deae87