### PR TITLE
Skip zero-weight Accept-Language entries

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -369,6 +369,14 @@ class AuroraClient
                     }
                 }
 
+                if ($quality <= 0) {
+                    continue;
+                }
+
+                if ($quality > 1) {
+                    $quality = 1.0;
+                }
+
                 if (!isset($prefLanguages[$locale]) || $quality > $prefLanguages[$locale]) {
                     $prefLanguages[$locale] = $quality;
                 }

--- a/tests/Utils/AuroraClient/PreferredLanguagesTest.php
+++ b/tests/Utils/AuroraClient/PreferredLanguagesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+
+final class PreferredLanguagesTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+    }
+
+    public function testSkipsLanguagesWithZeroQuality(): void
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US;q=1.0, fr;q=0, es;q=0.0, de;q=0.4';
+
+        $client = new AuroraClient();
+
+        self::assertSame(
+            [
+                'en-US' => 1.0,
+                'de'    => 0.4,
+            ],
+            $client->preferredLanguages()
+        );
+    }
+
+    public function testClampsQualityToMaximumOfOne(): void
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'es;q=1.5, it;q=2';
+
+        $client = new AuroraClient();
+
+        self::assertSame(
+            [
+                'es' => 1.0,
+                'it' => 1.0,
+            ],
+            $client->preferredLanguages()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- ignore zero-quality Accept-Language entries and clamp quality values above 1.0 in `AuroraClient::preferredLanguages`
- add unit coverage verifying quality skipping and clamping behaviour

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/AuroraClient/PreferredLanguagesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d046676fd08328b842099ac83687f6