### PR TITLE
Fix calendar links to use UTC timestamps

### DIFF
--- a/src/Utils/AuroraCalendarLinkGenerator/AuroraCalendarLinkGenerator.php
+++ b/src/Utils/AuroraCalendarLinkGenerator/AuroraCalendarLinkGenerator.php
@@ -14,14 +14,25 @@ class AuroraCalendarLinkGenerator
     {
     }
 
+    private function toUtcImmutable(\DateTimeInterface $date): \DateTimeImmutable
+    {
+        if ($date instanceof \DateTimeImmutable) {
+            $immutable = $date;
+        } else {
+            $immutable = \DateTimeImmutable::createFromInterface($date);
+        }
+
+        return $immutable->setTimezone(new \DateTimeZone('UTC'));
+    }
+
     private function formatDateForGoogle(\DateTimeInterface $date): string
     {
-        return $date->format('Ymd\THis');
+        return $this->toUtcImmutable($date)->format('Ymd\THis\Z');
     }
 
     private function formatDateForOutlook(\DateTimeInterface $date): string
     {
-        return $date->format('Y-m-d\TH:i:s');
+        return $this->toUtcImmutable($date)->format('Y-m-d\TH:i:s\Z');
     }
 
     public function getGoogleCalendarLink(): string

--- a/tests/Utils/AuroraCalendarLinkGenerator/AuroraCalendarLinkGeneratorTimezoneTest.php
+++ b/tests/Utils/AuroraCalendarLinkGenerator/AuroraCalendarLinkGeneratorTimezoneTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraCalendarLinkGenerator;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraCalendarLinkGenerator\AuroraCalendarLinkGenerator;
+
+class AuroraCalendarLinkGeneratorTimezoneTest extends TestCase
+{
+    public function testLinksUseUtcTimestamps(): void
+    {
+        $start = new \DateTimeImmutable('2025-04-15 10:00:00', new \DateTimeZone('America/New_York'));
+        $end   = new \DateTimeImmutable('2025-04-15 11:00:00', new \DateTimeZone('America/New_York'));
+
+        $generator = new AuroraCalendarLinkGenerator('Title', $start, $end, 'Description', 'Location');
+
+        $expectedGoogleDates = urlencode('20250415T140000Z/20250415T150000Z');
+        self::assertStringContainsString('dates=' . $expectedGoogleDates, $generator->getGoogleCalendarLink());
+
+        $yahooLink = $generator->getYahooCalendarLink();
+        self::assertStringContainsString('st=' . urlencode('20250415T140000Z'), $yahooLink);
+        self::assertStringContainsString('et=' . urlencode('20250415T150000Z'), $yahooLink);
+
+        $outlookLiveLink = $generator->getOutlookLiveCalendarLink();
+        self::assertStringContainsString('startdt=' . urlencode('2025-04-15T14:00:00Z'), $outlookLiveLink);
+        self::assertStringContainsString('enddt=' . urlencode('2025-04-15T15:00:00Z'), $outlookLiveLink);
+
+        $outlookOfficeLink = $generator->getOutlookOfficeCalendarLink();
+        self::assertStringContainsString('startdt=' . urlencode('2025-04-15T14:00:00Z'), $outlookOfficeLink);
+        self::assertStringContainsString('enddt=' . urlencode('2025-04-15T15:00:00Z'), $outlookOfficeLink);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize calendar link timestamps to UTC when building Google, Yahoo, and Outlook URLs
- add a PHPUnit test covering timezone conversion for the calendar link generator

## Testing
- `./vendor/bin/phpunit --no-coverage tests/Utils/AuroraCalendarLinkGenerator/AuroraCalendarLinkGeneratorTimezoneTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68d04b57a5f88328aed20946c4009434