### PR TITLE
Fix timezone handling in calendar today markers

### DIFF
--- a/src/Utils/AuroraCalendar/AuroraCalendar.php
+++ b/src/Utils/AuroraCalendar/AuroraCalendar.php
@@ -47,12 +47,16 @@ class AuroraCalendar
      *  - 'isToday': true if the date is today
      *  - 'isTomorrow': true if the date is tomorrow
      */
+    /**
+     * @return array<string, array{date: \DateTimeImmutable, dayOfTheWeek: int, isYesterday: bool, isToday: bool, isTomorrow: bool}>
+     */
     function generateCalendar(
         \DateTimeInterface  $startDate,
         ?\DateTimeInterface $endDate = null,
         int                 $firstDayOfTheWeek = 1,
         int                 $weeksBeforeFirstDay = 0,
-        int                 $weeksAfterLastDay = 0
+        int                 $weeksAfterLastDay = 0,
+        ?\DateTimeInterface $referenceDate = null
     ): array
     {
         // Ensure positive values for weeksBeforeFirstDay and weeksAfterLastDay
@@ -63,6 +67,21 @@ class AuroraCalendar
         $startDateImmutable = ($startDate instanceof \DateTimeImmutable)
             ? $startDate
             : \DateTimeImmutable::createFromInterface($startDate);
+
+        $referenceTimezone = $startDateImmutable->getTimezone();
+
+        if (null !== $referenceDate) {
+            $referenceDateTime = ($referenceDate instanceof \DateTimeImmutable)
+                ? $referenceDate
+                : \DateTimeImmutable::createFromInterface($referenceDate);
+            $referenceDateTime = $referenceDateTime->setTimezone($referenceTimezone);
+        } else {
+            $referenceDateTime = new \DateTimeImmutable('now', $referenceTimezone);
+        }
+
+        $todayStr     = $referenceDateTime->format('Y-m-d');
+        $yesterdayStr = $referenceDateTime->modify('-1 day')->format('Y-m-d');
+        $tomorrowStr  = $referenceDateTime->modify('+1 day')->format('Y-m-d');
 
         // Get the day number for $startDate (1 = Monday, 7 = Sunday)
         $currentDayNumber = (int)$startDateImmutable->format('N');
@@ -79,9 +98,6 @@ class AuroraCalendar
 
         // Adjust the start of the calendar by subtracting additional weeks before the current week
         $calendarStart = $weekStart->modify("-{$weeksBeforeFirstDay} weeks");
-
-        // Get today's date string for comparison
-        $todayStr = new \DateTimeImmutable('today')->format('Y-m-d');
 
         // If $endDate is provided, generate the calendar between startDate and endDate (with adjustments)
         if ($endDate !== null) {
@@ -112,7 +128,7 @@ class AuroraCalendar
             // Generate the calendar from $calendarStart to $calendarEnd (inclusive)
             $calendar = [];
             for ($currentDate = $calendarStart; $currentDate <= $calendarEnd; $currentDate = $currentDate->modify('+1 day')) {
-                $calendar = $this->_calendarArray($currentDate, $todayStr, $calendar);
+                $calendar = $this->_calendarArray($currentDate, $todayStr, $yesterdayStr, $tomorrowStr, $calendar);
             }
 
             return $calendar;
@@ -123,23 +139,33 @@ class AuroraCalendar
             $calendar    = [];
             $currentDate = $calendarStart;
             for ($i = 0; $i < $totalDays; $i++) {
-                $calendar    = $this->_calendarArray($currentDate, $todayStr, $calendar);
+                $calendar    = $this->_calendarArray($currentDate, $todayStr, $yesterdayStr, $tomorrowStr, $calendar);
                 $currentDate = $currentDate->modify('+1 day');
             }
             return $calendar;
         }
     }
 
-    private function _calendarArray(\DateTimeImmutable $currentDate, string $todayStr, array $calendar): array
+    /**
+     * @param array<string, array{date: \DateTimeImmutable, dayOfTheWeek: int, isYesterday: bool, isToday: bool, isTomorrow: bool}> $calendar
+     * @return array<string, array{date: \DateTimeImmutable, dayOfTheWeek: int, isYesterday: bool, isToday: bool, isTomorrow: bool}>
+     */
+    private function _calendarArray(
+        \DateTimeImmutable $currentDate,
+        string $todayStr,
+        string $yesterdayStr,
+        string $tomorrowStr,
+        array $calendar
+    ): array
     {
         $key            = $currentDate->format('Y-m-d');
         $dayOfTheWeek   = (int)$currentDate->format('N');
         $calendar[$key] = [
             'date'         => $currentDate,
             'dayOfTheWeek' => $dayOfTheWeek,
-            'isYesterday'  => $currentDate->format('Y-m-d') === new \DateTimeImmutable('yesterday')->format('Y-m-d'),
+            'isYesterday'  => $key === $yesterdayStr,
             'isToday'      => $key === $todayStr,
-            'isTomorrow'   => $currentDate->format('Y-m-d') === new \DateTimeImmutable('tomorrow')->format('Y-m-d'),
+            'isTomorrow'   => $key === $tomorrowStr,
         ];
         return $calendar;
     }

--- a/tests/Utils/AuroraCalendar/AuroraCalendarTest.php
+++ b/tests/Utils/AuroraCalendar/AuroraCalendarTest.php
@@ -223,4 +223,27 @@ class AuroraCalendarTest extends KernelTestCase
     }
 
     ###################################################################################################################################################################################################
+
+    public function testGenerateCalendarRespectsTimezoneForTodayMarkers(): void
+    {
+        $previousTz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+
+        try {
+            $calendar    = new AuroraCalendar();
+            $timezone    = new \DateTimeZone('Pacific/Kiritimati');
+            $start       = new \DateTimeImmutable('2024-01-02 08:00:00', $timezone);
+            $reference   = new \DateTimeImmutable('2024-01-02 09:00:00', $timezone);
+            $result      = $calendar->generateCalendar($start, null, 1, 0, 0, $reference);
+            $expectedKey = $start->format('Y-m-d');
+
+            self::assertArrayHasKey($expectedKey, $result);
+            self::assertTrue($result[$expectedKey]['isToday']);
+            self::assertFalse($result[$expectedKey]['isYesterday']);
+            self::assertFalse($result[$expectedKey]['isTomorrow']);
+        } finally {
+            date_default_timezone_set($previousTz);
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- adjust calendar generation to compare dates against a reference that uses the calendar timezone
- allow callers to provide a reference date to make relative day flags deterministic
- add a regression test covering timezone-aware today markers

## Testing
- KERNEL_CLASS=App\Kernel APP_ENV=test php vendor/bin/phpunit --no-coverage -c vendor/sindla/aurora/phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraCalendar/AuroraCalendarTest.php
- KERNEL_CLASS=App\Kernel APP_ENV=test php -d memory_limit=512M vendor/bin/phpstan analyse -l 6 vendor/sindla/aurora/src/Utils/AuroraCalendar/AuroraCalendar.php


------
https://chatgpt.com/codex/tasks/task_e_68d04b8c6b608328a12b513c7ecd1b4e