### PR TITLE
Normalize Accept-Language parsing in AuroraClient

### DIFF
--- a/src/Utils/AuroraClient/AuroraClient.php
+++ b/src/Utils/AuroraClient/AuroraClient.php
@@ -334,58 +334,105 @@ class AuroraClient
     {
         $prefLanguages = [];
 
-        if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-            $languages = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        if (!isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+            return $prefLanguages;
+        }
 
-            foreach ($languages as $language) {
-                $language = trim($language);
+        $languages = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        $normalizedLanguages = [];
 
-                if ($language === '') {
+        foreach ($languages as $language) {
+            $language = trim($language);
+
+            if ($language === '') {
+                continue;
+            }
+
+            $parts   = array_map('trim', explode(';', $language));
+            $locale  = array_shift($parts);
+            $quality = 1.0;
+
+            if ($locale === '' || $locale === null) {
+                continue;
+            }
+
+            foreach ($parts as $part) {
+                if ($part === '') {
                     continue;
                 }
 
-                $parts   = array_map('trim', explode(';', $language));
-                $locale  = array_shift($parts);
-                $quality = 1.0;
-
-                if ($locale === '' || $locale === null) {
+                if (!str_contains($part, '=')) {
                     continue;
                 }
 
-                foreach ($parts as $part) {
-                    if ($part === '') {
-                        continue;
-                    }
+                [$key, $value] = array_map('trim', explode('=', $part, 2));
 
-                    if (!str_contains($part, '=')) {
-                        continue;
-                    }
-
-                    [$key, $value] = array_map('trim', explode('=', $part, 2));
-
-                    if (strcasecmp($key, 'q') === 0 && is_numeric($value)) {
-                        $quality = (float) $value;
-                        break;
-                    }
-                }
-
-                if ($quality <= 0) {
-                    continue;
-                }
-
-                if ($quality > 1) {
-                    $quality = 1.0;
-                }
-
-                if (!isset($prefLanguages[$locale]) || $quality > $prefLanguages[$locale]) {
-                    $prefLanguages[$locale] = $quality;
+                if (strcasecmp($key, 'q') === 0 && is_numeric($value)) {
+                    $quality = (float) $value;
+                    break;
                 }
             }
 
-            arsort($prefLanguages);
+            if ($quality <= 0) {
+                continue;
+            }
+
+            if ($quality > 1) {
+                $quality = 1.0;
+            }
+
+            $normalizedLocale = $this->normalizeLocale($locale);
+            $mapKey           = strtolower($normalizedLocale);
+
+            if (
+                !isset($normalizedLanguages[$mapKey])
+                || $quality > $normalizedLanguages[$mapKey]['quality']
+            ) {
+                $normalizedLanguages[$mapKey] = [
+                    'locale'  => $normalizedLocale,
+                    'quality' => $quality,
+                ];
+            }
+        }
+
+        foreach ($normalizedLanguages as $data) {
+            $prefLanguages[$data['locale']] = $data['quality'];
+        }
+
+        if ($prefLanguages !== []) {
+            arsort($prefLanguages, SORT_NUMERIC);
         }
 
         return $prefLanguages;
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $normalized = str_replace('_', '-', $locale);
+        $parts      = explode('-', $normalized);
+
+        foreach ($parts as $index => $part) {
+            if ($part === '') {
+                continue;
+            }
+
+            if ($index === 0) {
+                $parts[$index] = strtolower($part);
+                continue;
+            }
+
+            $length = strlen($part);
+
+            if ($length === 2) {
+                $parts[$index] = strtoupper($part);
+            } elseif ($length === 4) {
+                $parts[$index] = ucfirst(strtolower($part));
+            } else {
+                $parts[$index] = strtolower($part);
+            }
+        }
+
+        return implode('-', $parts);
     }
 
     /**

--- a/tests/Utils/AuroraClient/AuroraClientPreferredLanguagesTest.php
+++ b/tests/Utils/AuroraClient/AuroraClientPreferredLanguagesTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraClient;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraClient\AuroraClient;
+
+final class AuroraClientPreferredLanguagesTest extends TestCase
+{
+    private ?string $previousAcceptLanguage;
+
+    protected function setUp(): void
+    {
+        $this->previousAcceptLanguage = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousAcceptLanguage === null) {
+            unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        } else {
+            $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $this->previousAcceptLanguage;
+        }
+    }
+
+    #[DataProvider('preferredLanguageProvider')]
+    public function testPreferredLanguagesNormalizesAndDeduplicates(string $header, array $expected): void
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $header;
+
+        $client = new AuroraClient();
+
+        self::assertSame($expected, $client->preferredLanguages());
+    }
+
+    public static function preferredLanguageProvider(): array
+    {
+        return [
+            'deduplicates differing case' => [
+                'en-us,en-US;q=0.5',
+                ['en-US' => 1.0],
+            ],
+            'prefers highest quality irrespective of case' => [
+                'en;q=0.5,EN;q=0.7',
+                ['en' => 0.7],
+            ],
+            'normalizes casing and separators' => [
+                'fr_fr;q=0.7,EN-gb;q=0.4',
+                ['fr-FR' => 0.7, 'en-GB' => 0.4],
+            ],
+            'keeps languages sorted by quality' => [
+                'en_US,fr_FR;q=0.8',
+                ['en-US' => 1.0, 'fr-FR' => 0.8],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- normalize Accept-Language parsing so language tags are canonicalized, deduplicated case-insensitively, and sorted by numeric preference
- add PHPUnit coverage for Accept-Language normalization and sorting scenarios

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist --no-coverage tests/Utils/AuroraClient/AuroraClientPreferredLanguagesTest.php
- ./vendor/bin/phpunit --configuration phpunit.xml.dist --no-coverage tests/Utils/AuroraClient/AuroraClientIpValidationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d060aac01883288c1fc6cb7c092628