### PR TITLE
Add PHPUnit coverage for AuroraArray helper

### DIFF
--- a/tests/Utils/AuroraArray/AuroraArrayTest.php
+++ b/tests/Utils/AuroraArray/AuroraArrayTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraArray;
+
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\AuroraArray\AuroraArray;
+
+class AuroraArrayTest extends TestCase
+{
+    private AuroraArray $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new AuroraArray();
+    }
+
+    public function testMultiDimensionalKeyExists(): void
+    {
+        $nested = [
+            'level_one' => [
+                'level_two' => [
+                    'target' => 'value',
+                ],
+            ],
+            'other_branch' => [
+                'another_key' => 'something',
+            ],
+        ];
+
+        $this->assertTrue($this->helper->multiDimensionalKeyExists('target', $nested));
+        $this->assertFalse($this->helper->multiDimensionalKeyExists('missing', $nested));
+    }
+
+    public function testToFlattenedDotPath(): void
+    {
+        $source = [
+            'alpha' => [
+                'beta' => 'first',
+                'gamma' => [
+                    'delta' => 'second',
+                ],
+            ],
+            'epsilon' => 'third',
+        ];
+
+        $expected = [
+            'alpha.beta' => 'first',
+            'alpha.gamma.delta' => 'second',
+            'epsilon' => 'third',
+        ];
+
+        $this->assertSame($expected, $this->helper->toFlattenedDotPath($source));
+    }
+
+    public function testToFlattenedDotPathWithPrefix(): void
+    {
+        $source = ['key' => 'value'];
+
+        $this->assertSame(
+            ['prefix.key' => 'value'],
+            $this->helper->toFlattenedDotPath($source, 'prefix.')
+        );
+    }
+
+    public function testKSortRecursive(): void
+    {
+        $input = [
+            'zeta' => [
+                'beta' => 2,
+                'alpha' => 1,
+            ],
+            'eta' => [
+                'delta' => [
+                    'charlie' => 3,
+                    'bravo' => 4,
+                ],
+                'alpha' => 0,
+            ],
+        ];
+
+        $expected = [
+            'eta' => [
+                'alpha' => 0,
+                'delta' => [
+                    'bravo' => 4,
+                    'charlie' => 3,
+                ],
+            ],
+            'zeta' => [
+                'alpha' => 1,
+                'beta' => 2,
+            ],
+        ];
+
+        $this->assertSame($expected, $this->helper->kSortRecursive($input));
+    }
+}


### PR DESCRIPTION
## Summary
- add focused tests for multi-level key lookups and dot path flattening in AuroraArray
- cover recursive key sorting behaviour in AuroraArray

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php vendor/bin/phpunit --no-coverage -c vendor/sindla/aurora/phpunit.xml.dist vendor/sindla/aurora/tests/`


------
https://chatgpt.com/codex/tasks/task_e_68d06558fdfc83289fbfc1f1371e58de