### PR TITLE
Add unit tests for HtmlFormatter

### DIFF
--- a/tests/Monolog/LoggerStub.php
+++ b/tests/Monolog/LoggerStub.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Bridge\Monolog;
+
+if (!class_exists(Logger::class)) {
+    class Logger
+    {
+        public const DEBUG = 100;
+        public const INFO = 200;
+        public const NOTICE = 250;
+        public const WARNING = 300;
+        public const ERROR = 400;
+        public const CRITICAL = 500;
+        public const ALERT = 550;
+        public const EMERGENCY = 600;
+    }
+}

--- a/tests/Monolog/NormalizerFormatterStub.php
+++ b/tests/Monolog/NormalizerFormatterStub.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Monolog\Formatter;
+
+use DateTimeInterface;
+
+if (!class_exists(NormalizerFormatter::class)) {
+    class NormalizerFormatter
+    {
+        protected string $dateFormat;
+
+        public function __construct(?string $dateFormat = null)
+        {
+            $this->dateFormat = $dateFormat ?? DateTimeInterface::RFC3339_EXTENDED;
+        }
+
+        protected function normalize(mixed $data): mixed
+        {
+            if ($data instanceof DateTimeInterface) {
+                return $data->format($this->dateFormat);
+            }
+
+            if (is_array($data)) {
+                $normalized = [];
+                foreach ($data as $key => $value) {
+                    $normalized[$key] = $this->normalize($value);
+                }
+
+                return $normalized;
+            }
+
+            if (is_object($data)) {
+                return $this->normalize(get_object_vars($data));
+            }
+
+            return $data;
+        }
+    }
+}

--- a/tests/Utils/Monolog/HtmlFormatterTest.php
+++ b/tests/Utils/Monolog/HtmlFormatterTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Monolog;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Sindla\Bundle\AuroraBundle\Utils\Monolog\HtmlFormatter;
+use Symfony\Bridge\Monolog\Logger;
+
+final class TestableHtmlFormatter extends HtmlFormatter
+{
+    public function callAddRow(string $th, string $td = ' ', bool $escapeTd = true): string
+    {
+        return $this->addRow($th, $td, $escapeTd);
+    }
+
+    public function callAddTitle(string $title, int $level): string
+    {
+        return $this->addTitle($title, $level);
+    }
+
+    public function callConvertToString(mixed $data): string
+    {
+        return $this->convertToString($data);
+    }
+}
+
+class HtmlFormatterTest extends TestCase
+{
+    public function testFormatGeneratesEscapedTableWithNestedContext(): void
+    {
+        $formatter = new HtmlFormatter('Y-m-d H:i:s');
+
+        $record = [
+            'message'    => 'A <strong>message</strong>',
+            'context'    => [
+                'payload' => ['nested' => 'value'],
+            ],
+            'level'      => Logger::WARNING,
+            'level_name' => 'WARNING',
+            'channel'    => 'app',
+            'datetime'   => new DateTimeImmutable('2024-01-02 03:04:05'),
+            'extra'      => [
+                'user' => 'alice',
+            ],
+            'misc'       => [
+                'Custom' => '<tag>value</tag>',
+            ],
+        ];
+
+        $html = $formatter->format($record);
+
+        $this->assertStringContainsString('<h1 style="background: #c09853;color: #ffffff;padding: 5px;" class="monolog-output">WARNING</h1>', $html);
+        $this->assertStringContainsString('&lt;strong&gt;message&lt;/strong&gt;', $html);
+        $this->assertStringContainsString('<th style="background: #cccccc" width="100px">Custom:</th>', $html);
+        $this->assertStringContainsString('&lt;tag&gt;value&lt;/tag&gt;', $html);
+        $this->assertStringContainsString('"nested": "value"', $html);
+        $this->assertStringContainsString('Context', $html);
+        $this->assertStringContainsString('Extra', $html);
+    }
+
+    public function testAddRowEscapesTableDataByDefault(): void
+    {
+        $formatter = new TestableHtmlFormatter();
+
+        $row = $formatter->callAddRow('Header', '<em>content</em>');
+
+        $this->assertStringContainsString('&lt;em&gt;content&lt;/em&gt;', $row);
+    }
+
+    public function testAddRowAllowsHtmlWhenDisabled(): void
+    {
+        $formatter = new TestableHtmlFormatter();
+
+        $row = $formatter->callAddRow('Header', '<em>content</em>', false);
+
+        $this->assertStringContainsString('<em>content</em>', $row);
+    }
+
+    public function testFormatBatchConcatenatesFormattedMessages(): void
+    {
+        $formatter = new HtmlFormatter();
+
+        $records = [
+            $this->createRecord('First message'),
+            $this->createRecord('Second message'),
+        ];
+
+        $batchHtml = $formatter->formatBatch($records);
+
+        $this->assertSame(2, substr_count($batchHtml, '<table cellspacing="1" width="100%" class="monolog-output">'));
+        $this->assertStringContainsString('First message', $batchHtml);
+        $this->assertStringContainsString('Second message', $batchHtml);
+    }
+
+    public function testConvertToStringNormalizesStructuredData(): void
+    {
+        $formatter = new TestableHtmlFormatter();
+
+        $json = $formatter->callConvertToString(['foo' => ['bar' => 'baz']]);
+        $this->assertSame("{\n    \"foo\": {\n        \"bar\": \"baz\"\n    }\n}", $json);
+
+        $this->assertSame('', $formatter->callConvertToString(null));
+        $this->assertSame('42', $formatter->callConvertToString(42));
+    }
+
+    private function createRecord(string $message): array
+    {
+        return [
+            'message'    => $message,
+            'context'    => [],
+            'level'      => Logger::INFO,
+            'level_name' => 'INFO',
+            'channel'    => 'app',
+            'datetime'   => new DateTimeImmutable(),
+            'extra'      => [],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,14 @@ if (!class_exists(\Twig\Extension\AbstractExtension::class)) {
     );
 }
 
+if (!class_exists(\Monolog\Formatter\NormalizerFormatter::class)) {
+    require_once __DIR__ . '/Monolog/NormalizerFormatterStub.php';
+}
+
+if (!class_exists(\Symfony\Bridge\Monolog\Logger::class)) {
+    require_once __DIR__ . '/Monolog/LoggerStub.php';
+}
+
 if (file_exists(dirname(__DIR__) . '/config/bootstrap.php')) {
     require dirname(__DIR__) . '/config/bootstrap.php';
 } else if (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
## Summary
- add focused unit tests covering the HtmlFormatter utility
- provide Monolog formatter and logger stubs so the bundle tests run without the real dependency
- wire the new stubs into the PHPUnit bootstrap sequence

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Utils/Monolog/HtmlFormatterTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d06709161c83288b1da63d576e8d5c