### PR TITLE
Fix Monolog logger stub loading in test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,7 +35,27 @@ if (!class_exists(\Monolog\Formatter\NormalizerFormatter::class)) {
 }
 
 if (!class_exists(\Symfony\Bridge\Monolog\Logger::class)) {
-    require_once __DIR__ . '/Monolog/LoggerStub.php';
+    $monologLoggerStub = __DIR__ . '/Monolog/LoggerStub.php';
+
+    if (is_file($monologLoggerStub)) {
+        require_once $monologLoggerStub;
+    } else {
+        if (!class_exists('AuroraTestsMonologLoggerStubFallback', false)) {
+            class AuroraTestsMonologLoggerStubFallback
+            {
+                public const int DEBUG     = 100;
+                public const int INFO      = 200;
+                public const int NOTICE    = 250;
+                public const int WARNING   = 300;
+                public const int ERROR     = 400;
+                public const int CRITICAL  = 500;
+                public const int ALERT     = 550;
+                public const int EMERGENCY = 600;
+            }
+        }
+
+        class_alias('AuroraTestsMonologLoggerStubFallback', \Symfony\Bridge\Monolog\Logger::class);
+    }
 }
 
 if (file_exists(dirname(__DIR__) . '/config/bootstrap.php')) {


### PR DESCRIPTION
## Summary
- fallback to the bundled Monolog Logger stub when the file is accessible
- provide an in-memory Logger stub alias when the file cannot be loaded

## Testing
- ./vendor/bin/phpunit --no-coverage

------
https://chatgpt.com/codex/tasks/task_e_68d0e3fb790c83289d0ce0a8c76f2f13