### PR TITLE
Support Monolog LogRecord in HTML formatter tests

### DIFF
--- a/src/Utils/Monolog/HtmlFormatter.php
+++ b/src/Utils/Monolog/HtmlFormatter.php
@@ -94,8 +94,23 @@ class HtmlFormatter extends NormalizerFormatter
         $channel = $normalizedRecord['channel'] ?? $record->channel;
         $output .= $this->addRow('Channel', (string) $channel);
 
+        $miscData = null;
         if (isset($normalizedRecord['misc']) && \is_array($normalizedRecord['misc'])) {
-            foreach ($normalizedRecord['misc'] as $miscKey => $miscValue) {
+            $miscData = $normalizedRecord['misc'];
+        }
+
+        $extra = $record->extra;
+        if (isset($extra['misc']) && \is_array($extra['misc'])) {
+            $miscData ??= $extra['misc'];
+            unset($extra['misc']);
+        }
+
+        if (isset($normalizedRecord['extra']['misc']) && \is_array($normalizedRecord['extra']['misc'])) {
+            $miscData ??= $normalizedRecord['extra']['misc'];
+        }
+
+        if (\is_array($miscData)) {
+            foreach ($miscData as $miscKey => $miscValue) {
                 $output .= $this->addRow($miscKey, (string) $miscValue);
             }
         }
@@ -109,9 +124,9 @@ class HtmlFormatter extends NormalizerFormatter
             $output .= $this->addRow('Context', $embeddedTable, false);
         }
 
-        if ($record->extra) {
+        if ($extra) {
             $embeddedTable = '<table cellspacing="1" width="100%">';
-            foreach ($record->extra as $key => $value) {
+            foreach ($extra as $key => $value) {
                 $embeddedTable .= $this->addRow($key, $this->convertToString($value));
             }
             $embeddedTable .= '</table>';

--- a/tests/Monolog/LevelStub.php
+++ b/tests/Monolog/LevelStub.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Monolog;
+
+if (!enum_exists(Level::class)) {
+    enum Level: int
+    {
+        case Debug = 100;
+        case Info = 200;
+        case Notice = 250;
+        case Warning = 300;
+        case Error = 400;
+        case Critical = 500;
+        case Alert = 550;
+        case Emergency = 600;
+
+        public static function fromName(string $name): self
+        {
+            return match (strtolower($name)) {
+                'debug' => self::Debug,
+                'info' => self::Info,
+                'notice' => self::Notice,
+                'warning' => self::Warning,
+                'error' => self::Error,
+                'critical' => self::Critical,
+                'alert' => self::Alert,
+                'emergency' => self::Emergency,
+                default => throw new \InvalidArgumentException(sprintf('Unknown level name "%s".', $name)),
+            };
+        }
+
+        public static function fromValue(int $value): self
+        {
+            return match ($value) {
+                self::Debug->value => self::Debug,
+                self::Info->value => self::Info,
+                self::Notice->value => self::Notice,
+                self::Warning->value => self::Warning,
+                self::Error->value => self::Error,
+                self::Critical->value => self::Critical,
+                self::Alert->value => self::Alert,
+                self::Emergency->value => self::Emergency,
+                default => throw new \InvalidArgumentException(sprintf('Unknown level value "%d".', $value)),
+            };
+        }
+
+        public function getName(): string
+        {
+            return match ($this) {
+                self::Debug => 'DEBUG',
+                self::Info => 'INFO',
+                self::Notice => 'NOTICE',
+                self::Warning => 'WARNING',
+                self::Error => 'ERROR',
+                self::Critical => 'CRITICAL',
+                self::Alert => 'ALERT',
+                self::Emergency => 'EMERGENCY',
+            };
+        }
+    }
+}

--- a/tests/Monolog/LogRecordStub.php
+++ b/tests/Monolog/LogRecordStub.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Monolog;
+
+use DateTimeImmutable;
+
+if (!class_exists(LogRecord::class)) {
+    class LogRecord
+    {
+        public function __construct(
+            public DateTimeImmutable $datetime,
+            public string $channel,
+            public Level $level,
+            public string $message,
+            public array $context = [],
+            public array $extra = [],
+            public mixed $formatted = null,
+        ) {
+        }
+
+        public function toArray(): array
+        {
+            return [
+                'message' => $this->message,
+                'context' => $this->context,
+                'level' => $this->level->value,
+                'level_name' => $this->level->getName(),
+                'channel' => $this->channel,
+                'datetime' => $this->datetime,
+                'extra' => $this->extra,
+            ];
+        }
+    }
+}

--- a/tests/Monolog/NormalizerFormatterStub.php
+++ b/tests/Monolog/NormalizerFormatterStub.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Monolog\Formatter;
 
 use DateTimeInterface;
+use Monolog\LogRecord;
 
 if (!class_exists(NormalizerFormatter::class)) {
     class NormalizerFormatter
@@ -14,6 +15,11 @@ if (!class_exists(NormalizerFormatter::class)) {
         public function __construct(?string $dateFormat = null)
         {
             $this->dateFormat = $dateFormat ?? DateTimeInterface::RFC3339_EXTENDED;
+        }
+
+        public function format(LogRecord $record)
+        {
+            return $this->normalize($record->toArray());
         }
 
         protected function normalize(mixed $data): mixed

--- a/tests/Utils/Monolog/HtmlFormatterTest.php
+++ b/tests/Utils/Monolog/HtmlFormatterTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\Monolog;
 
 use DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\Monolog\HtmlFormatter;
-use Symfony\Bridge\Monolog\Logger;
 
 final class TestableHtmlFormatter extends HtmlFormatter
 {
@@ -33,22 +34,21 @@ class HtmlFormatterTest extends TestCase
     {
         $formatter = new HtmlFormatter('Y-m-d H:i:s');
 
-        $record = [
-            'message'    => 'A <strong>message</strong>',
-            'context'    => [
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2024-01-02 03:04:05'),
+            channel: 'app',
+            level: Level::Warning,
+            message: 'A <strong>message</strong>',
+            context: [
                 'payload' => ['nested' => 'value'],
             ],
-            'level'      => Logger::WARNING,
-            'level_name' => 'WARNING',
-            'channel'    => 'app',
-            'datetime'   => new DateTimeImmutable('2024-01-02 03:04:05'),
-            'extra'      => [
+            extra: [
                 'user' => 'alice',
+                'misc' => [
+                    'Custom' => '<tag>value</tag>',
+                ],
             ],
-            'misc'       => [
-                'Custom' => '<tag>value</tag>',
-            ],
-        ];
+        );
 
         $html = $formatter->format($record);
 
@@ -106,16 +106,13 @@ class HtmlFormatterTest extends TestCase
         $this->assertSame('42', $formatter->callConvertToString(42));
     }
 
-    private function createRecord(string $message): array
+    private function createRecord(string $message): LogRecord
     {
-        return [
-            'message'    => $message,
-            'context'    => [],
-            'level'      => Logger::INFO,
-            'level_name' => 'INFO',
-            'channel'    => 'app',
-            'datetime'   => new DateTimeImmutable(),
-            'extra'      => [],
-        ];
+        return new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: $message,
+        );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,14 @@ if (!class_exists(\Twig\Extension\AbstractExtension::class)) {
     );
 }
 
+if (!enum_exists(\Monolog\Level::class)) {
+    require_once __DIR__ . '/Monolog/LevelStub.php';
+}
+
+if (!class_exists(\Monolog\LogRecord::class)) {
+    require_once __DIR__ . '/Monolog/LogRecordStub.php';
+}
+
 if (!class_exists(\Monolog\Formatter\NormalizerFormatter::class)) {
     require_once __DIR__ . '/Monolog/NormalizerFormatterStub.php';
 }


### PR DESCRIPTION
## Summary
- update the HTML formatter to read misc data from LogRecord extras while keeping the extra table intact
- exercise HtmlFormatterTest with Monolog\LogRecord instances instead of raw arrays
- provide Monolog Level/LogRecord stubs and adjust the NormalizerFormatter stub/bootstrap to load them when Monolog is absent

## Testing
- vendor/bin/phpunit --configuration phpunit.xml.dist --filter HtmlFormatterTest --no-coverage


------
https://chatgpt.com/codex/tasks/task_e_68d0f342eec48328955fefb3c78584b0