### PR TITLE
Add robust date suffix helper with tests

### DIFF
--- a/src/Utils/AuroraCalendar/AuroraCalendar.php
+++ b/src/Utils/AuroraCalendar/AuroraCalendar.php
@@ -8,6 +8,43 @@ use Sindla\Bundle\AuroraBundle\Utils\AuroraChronos\AuroraChronos;
 class AuroraCalendar
 {
     /**
+     * Returns the ordinal suffix for the provided calendar day.
+     */
+    public function dateSuffix(int|string $day): string
+    {
+        if (is_string($day)) {
+            $day = trim($day);
+
+            if ($day === '') {
+                throw new \InvalidArgumentException('Day value cannot be empty.');
+            }
+
+            if (!preg_match('/^-?\d+$/', $day)) {
+                throw new \InvalidArgumentException('Day value must be an integer represented as a string.');
+            }
+
+            $day = (int)$day;
+        }
+
+        if ($day < 1 || $day > 31) {
+            throw new \InvalidArgumentException('Day value must be between 1 and 31.');
+        }
+
+        $dayModuloHundred = $day % 100;
+
+        if (in_array($dayModuloHundred, [11, 12, 13], true)) {
+            return 'th';
+        }
+
+        return match ($day % 10) {
+            1       => 'st',
+            2       => 'nd',
+            3       => 'rd',
+            default => 'th',
+        };
+    }
+
+    /**
      * Return the number of days for a full weeks calendar
      * Month's days + the number of days before the first day of the month + the number of days after the last day of the month
      * Always will return number divisible by 7 (because one full week has 7 days)

--- a/tests/Utils/AuroraCalendar/AuroraCalendarTest.php
+++ b/tests/Utils/AuroraCalendar/AuroraCalendarTest.php
@@ -21,6 +21,56 @@ class AuroraCalendarTest extends KernelTestCase
         $this->containerTest = $this->kernelTest->getContainer();
     }
 
+    #[DataProvider('dataDateSuffix')]
+    public function testDateSuffix(string $expected, int|string $given): void
+    {
+        $auroraCalendar = new AuroraCalendar();
+
+        $this->assertSame($expected, $auroraCalendar->dateSuffix($given));
+    }
+
+    public static function dataDateSuffix(): array
+    {
+        return [
+            ['st', 1],
+            ['nd', 2],
+            ['rd', 3],
+            ['th', 4],
+            ['th', 11],
+            ['th', 12],
+            ['th', 13],
+            ['st', 21],
+            ['nd', 22],
+            ['rd', 23],
+            ['st', 31],
+            ['nd', '02'],
+            ['st', ' 21 '],
+        ];
+    }
+
+    #[DataProvider('dataInvalidDateSuffix')]
+    public function testDateSuffixWithInvalidValue(int|string $given): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new AuroraCalendar())->dateSuffix($given);
+    }
+
+    public static function dataInvalidDateSuffix(): array
+    {
+        return [
+            [0],
+            ['0'],
+            [32],
+            ['32'],
+            [''],
+            ['   '],
+            ['abc'],
+            ['-1'],
+            [-5],
+        ];
+    }
+
     ###################################################################################################################################################################################################
 
     #[DataProvider('dataWeekDaysFromPreviousMonthBeforeFirstDayOfTheMonth')]


### PR DESCRIPTION
## Summary
- add validation and ordinal suffix handling to `AuroraCalendar::dateSuffix`
- cover valid and invalid inputs with new PHPUnit data providers

## Testing
- APP_ENV=test ./vendor/bin/phpunit --no-coverage *(fails: KERNEL_CLASS environment variable is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d225936b388328be4399edf1874e5d