### PR TITLE
Add unit tests for MetaTrait

### DIFF
--- a/tests/Entity/SuperAttribute/Misc/MetaTraitTest.php
+++ b/tests/Entity/SuperAttribute/Misc/MetaTraitTest.php
@@ -4,22 +4,89 @@ declare(strict_types=1);
 namespace Sindla\Bundle\AuroraBundle\Tests\Entity\SuperAttribute\Misc;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\HttpClient\HttpClient;
 use Sindla\Bundle\AuroraBundle\Entity\SuperAttribute\Misc\MetaTrait;
 
-/**
- * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Entity/SuperAttribute/Misc/MetaTraitTest.php --no-coverage
- */
-class MetaTraitTest extends KernelTestCase
+class MetaTraitWrapper
 {
-    private $kernelTest;
-    private $containerTest;
+    use MetaTrait;
+}
+
+class MetaTraitTest extends TestCase
+{
+    private MetaTraitWrapper $metaTrait;
 
     protected function setUp(): void
     {
-        $this->kernelTest    = self::bootKernel();
-        $this->containerTest = $this->kernelTest->getContainer();
+        $this->metaTrait = new MetaTraitWrapper();
+    }
+
+    public function testGetMetaReturnsEmptyArrayByDefault(): void
+    {
+        self::assertSame([], $this->metaTrait->getMeta());
+    }
+
+    public function testSetMetaOverridesCurrentMeta(): void
+    {
+        $meta = ['title' => 'Aurora'];
+
+        $result = $this->metaTrait->setMeta($meta);
+
+        self::assertSame($this->metaTrait, $result);
+        self::assertSame($meta, $this->metaTrait->getMeta());
+    }
+
+    public function testAddMetaAppendsValue(): void
+    {
+        $this->metaTrait->setMeta(['initial']);
+
+        $result = $this->metaTrait->addMeta('appended');
+
+        self::assertSame($this->metaTrait, $result);
+        self::assertSame(['initial', 'appended'], $this->metaTrait->getMeta());
+    }
+
+    public function testMergeMetaCombinesExistingValues(): void
+    {
+        $this->metaTrait->setMeta(['title' => 'Aurora']);
+
+        $result = $this->metaTrait->mergeMeta(['description' => 'Bundle']);
+
+        self::assertSame($this->metaTrait, $result);
+        self::assertSame(
+            ['title' => 'Aurora', 'description' => 'Bundle'],
+            $this->metaTrait->getMeta()
+        );
+    }
+
+    public function testInjectMetaBehavesLikeMerge(): void
+    {
+        $this->metaTrait->setMeta(['title' => 'Aurora']);
+
+        $result = $this->metaTrait->injectMeta(['language' => 'PHP']);
+
+        self::assertSame($this->metaTrait, $result);
+        self::assertSame(
+            ['title' => 'Aurora', 'language' => 'PHP'],
+            $this->metaTrait->getMeta()
+        );
+    }
+
+    public function testRemoveMetaDeletesExistingValue(): void
+    {
+        $this->metaTrait->setMeta(['keep', 'remove']);
+
+        $result = $this->metaTrait->removeMeta('remove');
+
+        self::assertSame($this->metaTrait, $result);
+        self::assertSame(['keep'], $this->metaTrait->getMeta());
+    }
+
+    public function testRemoveMetaIgnoresMissingValue(): void
+    {
+        $this->metaTrait->setMeta(['keep']);
+
+        $this->metaTrait->removeMeta('missing');
+
+        self::assertSame(['keep'], $this->metaTrait->getMeta());
     }
 }


### PR DESCRIPTION
## Summary
- add PHPUnit coverage for the MetaTrait accessors and mutators

## Testing
- `KERNEL_CLASS=App\Kernel APP_ENV=test php /workspace/Aurora-installed/vendor/bin/phpunit --no-coverage -c /workspace/Aurora-installed/vendor/sindla/aurora/phpunit.xml.dist /workspace/Aurora-installed/vendor/sindla/aurora/tests/` *(fails: RuntimeException - AppKernel missing in bundle test suite)*
- `KERNEL_CLASS=App\Kernel APP_ENV=test php -d memory_limit=1G /workspace/Aurora-installed/vendor/bin/phpstan analyse -l 6 /workspace/Aurora-installed/vendor/sindla/aurora//src` *(fails: pre-existing errors across bundle codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c9e266948328895d0b24c7424ab7