### PR TITLE
Fix ParameterBag injection for PHPUnit command

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -82,7 +82,7 @@ services:
     # Register PHPUnit command (see the class file for the command name)
     aurora.command.php_unit:
         class: Sindla\Bundle\AuroraBundle\Command\PHPUnitCommand
-        arguments: ['@service_container']
+        arguments: ['@parameter_bag']
         tags:
             - { name: console.command }
 


### PR DESCRIPTION
## Summary
- update the service definition for the PHPUnit command to inject the parameter bag instead of the whole container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1fe0aec408328bca0d34e3048868e