### PR TITLE
Add PHPUnit coverage for AuroraHelper utilities

### DIFF
--- a/tests/Utils/AuroraHelper/AuroraHelperTest.php
+++ b/tests/Utils/AuroraHelper/AuroraHelperTest.php
@@ -3,23 +3,14 @@ declare(strict_types=1);
 
 namespace Sindla\Bundle\AuroraBundle\Tests\Utils\AuroraHelper;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use PHPUnit\Framework\TestCase;
 use Sindla\Bundle\AuroraBundle\Utils\AuroraHelper\AuroraHelper;
 
 /**
  * clear; php phpunit.phar -c phpunit.xml.dist vendor/sindla/aurora/tests/Utils/AuroraHelper/AuroraHelperTest.php --no-coverage
  */
-class AuroraHelperTest extends KernelTestCase
+class AuroraHelperTest extends TestCase
 {
-    private $kernelTest;
-    private $containerTest;
-
-    protected function setUp(): void
-    {
-        $this->kernelTest    = self::bootKernel();
-        $this->containerTest = $this->kernelTest->getContainer();
-    }
-
     public function testArrayToFlattenedDotPath(): void
     {
         $Helper = new AuroraHelper();
@@ -45,5 +36,64 @@ class AuroraHelperTest extends KernelTestCase
         ];
 
         $this->assertEquals($flattenedArray, $Helper->arrayToFlattenedDotPath($nestedArray));
+    }
+
+    public function testArrayMultidimensionalKeyExists(): void
+    {
+        $helper = new AuroraHelper();
+
+        $array = [
+            'first'  => 'value',
+            'nested' => [
+                'second' => [
+                    'target' => 'found',
+                ],
+            ],
+        ];
+
+        $this->assertTrue($helper->arrayMultidimensionalKeyExists('target', $array));
+        $this->assertFalse($helper->arrayMultidimensionalKeyExists('missing', $array));
+    }
+
+    public function testKsortRecursive(): void
+    {
+        $helper = new AuroraHelper();
+
+        $unordered = [
+            'b' => [
+                'delta' => 4,
+                'alpha' => 1,
+            ],
+            'a' => [
+                'charlie' => 3,
+                'bravo'   => 2,
+            ],
+        ];
+
+        $expected = [
+            'a' => [
+                'bravo'   => 2,
+                'charlie' => 3,
+            ],
+            'b' => [
+                'alpha' => 1,
+                'delta' => 4,
+            ],
+        ];
+
+        $this->assertSame($expected, $helper->ksortRecursive($unordered));
+    }
+
+    public function testIsTrueAndIsFalse(): void
+    {
+        $helper = new AuroraHelper();
+
+        $this->assertTrue($helper->isTrue('1'));
+        $this->assertTrue($helper->isTrue('true'));
+        $this->assertFalse($helper->isTrue('no'));
+
+        $this->assertTrue($helper->isFalse('0'));
+        $this->assertTrue($helper->isFalse('false'));
+        $this->assertFalse($helper->isFalse('yes'));
     }
 }


### PR DESCRIPTION
## Summary
- run the AuroraHelper unit tests without a Symfony kernel dependency
- add coverage for the array key lookup, recursive sort, and boolean helper methods

## Testing
- vendor/bin/phpunit --no-coverage tests/Utils/AuroraHelper/AuroraHelperTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f4f1fdde348328b624c9cd486d3d24