### PR TITLE
Add PHPUnit coverage for monthFromYearAndWeek most day option

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -106,6 +106,7 @@ jobs:
 
                     echo -e "\033[0;35m * sync files \033[0m"
                     cp -rf "${{ env.WORKSPACE }}/src/"* "${{ env.BUILD_DIR }}/vendor/sindla/aurora/src"
+                    cp -rf "${{ env.WORKSPACE }}/tests/"* "${{ env.BUILD_DIR }}/vendor/sindla/aurora/tests"
                     cp -f ${{ env.WORKSPACE }}/src/Resources/schema/packages/aurora.yaml ${{ env.BUILD_DIR }}/config/packages/aurora.yaml
                     cat ${{ env.WORKSPACE }}/src/Resources/schema/routes.append.yaml >> ${{ env.BUILD_DIR }}/config/routes.yaml
                     cp -f ${{ env.WORKSPACE }}/tests/bootstrap.php ${{ env.BUILD_DIR }}/tests/bootstrap.php

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,6 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.3",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^12.3"
+        "phpunit/phpunit": "^12.4"
     }
 }

--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -401,7 +401,8 @@ class AuroraChronos
     {
         try {
             // Create \DateTime for Monday of the specified week
-            $date = \DateTime::createFromFormat('o-W', sprintf('%d-%02d', $year, $week));
+            // Format: 'o-W-N' where N is day of week (1=Monday, 7=Sunday)
+            $date = \DateTime::createFromFormat('o-W-N', sprintf('%d-%02d-1', $year, $week));
 
             // If $day is 'most' calculate which month has most days in this week
             if (strtolower($day) === self::DAY_MOST) {

--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -576,7 +576,6 @@ class AuroraChronos
         return $datetime && $datetime->format($format) == $date;
     }
 
-
     /**
      * Convert a time string to seconds
      *   eg: 30s => 30, 15m => 900, 1h => 3600, 2d => 172800, 3w => 1814400, 4mo => 10368000, 5y => 157680000

--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -403,7 +403,12 @@ class AuroraChronos
             // Create \DateTime for Monday of the specified week using setISODate
             $date = new \DateTime();
             $date->setISODate($year, $week, 1); // 1 = Monday
-            $date->setTime(0, 0, 0);   // Reset time to midnight
+            $date->setTime(0, 0, 0); // Reset time to midnight
+
+            // DEBUG: Remove after testing
+            var_dump("After setISODate: " . $date->format('Y-m-d'));
+            var_dump("Day parameter: " . $day);
+            var_dump("DAY_MOST constant: " . self::DAY_MOST);
 
             // If $day is 'most' calculate which month has most days in this week
             if (strtolower($day) === self::DAY_MOST) {
@@ -423,6 +428,10 @@ class AuroraChronos
             };
 
             $date->modify("+{$daysToAdd} days");
+
+            // DEBUG: Remove after testing
+            var_dump("After modify: " . $date->format('Y-m-d'));
+            var_dump("Returning month: " . $date->format('n'));
 
             return (int)$date->format('n');
         } catch (\Exception $e) {

--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -397,7 +397,7 @@ class AuroraChronos
             ) * -1;
     }
 
-    public function monthFromYearAndWeek(int $year, int $week, string $day = self::DAY_MONDAY): int
+    public function monthFromYearAndWeek(int $year, int $week, string $day = self::DAY_MOST): int
     {
         try {
             // Create \DateTime for Monday of the specified week

--- a/src/Utils/AuroraChronos/AuroraChronos.php
+++ b/src/Utils/AuroraChronos/AuroraChronos.php
@@ -400,9 +400,10 @@ class AuroraChronos
     public function monthFromYearAndWeek(int $year, int $week, string $day = self::DAY_MOST): int
     {
         try {
-            // Create \DateTime for Monday of the specified week
-            // Format: 'o-W-N' where N is day of week (1=Monday, 7=Sunday)
-            $date = \DateTime::createFromFormat('o-W-N', sprintf('%d-%02d-1', $year, $week));
+            // Create \DateTime for Monday of the specified week using setISODate
+            $date = new \DateTime();
+            $date->setISODate($year, $week, 1); // 1 = Monday
+            $date->setTime(0, 0, 0);   // Reset time to midnight
 
             // If $day is 'most' calculate which month has most days in this week
             if (strtolower($day) === self::DAY_MOST) {

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -532,6 +532,9 @@ class AuroraChronosTest extends TestCase
     {
         $chronos = new AuroraChronos();
 
+        // DEBUG
+        var_dump("TEST: year=$year, week=$week, day=$day, expected=$expectedMonth");
+
         self::assertSame($expectedMonth, $chronos->monthFromYearAndWeek($year, $week, $day));
     }
 

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -539,6 +539,8 @@ class AuroraChronosTest extends TestCase
 
     public static function providerMonthFromYearAndWeek(): array
     {
+        echo "\n=== PROVIDER CALLED ===\n";
+
         $data = [
             // ISO week 1 of 2024 starts on 2024-01-01 (Monday) => January
             [2024, 1, AuroraChronos::DAY_MONDAY, 1],

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -533,6 +533,17 @@ class AuroraChronosTest extends TestCase
         self::assertSame($expectedMonth, $chronos->monthFromYearAndWeek($year, $week));
     }
 
+    #[DataProvider('providerMonthFromYearAndWeekMost')]
+    public function testMonthFromYearAndWeekWithMostDay(int $year, int $week, int $expectedMonth): void
+    {
+        $chronos = new AuroraChronos();
+
+        self::assertSame(
+            $expectedMonth,
+            $chronos->monthFromYearAndWeek($year, $week, AuroraChronos::DAY_MOST)
+        );
+    }
+
     public static function providerMonthFromYearAndWeek(): array
     {
         return [
@@ -545,6 +556,18 @@ class AuroraChronosTest extends TestCase
             // ISO week 1 of 2022 starts on 2022-01-03 => January
             [2022, 1, 1],
             // ISO week 53 of 2015 spans 2015-12-28..2016-01-03 => December
+            [2015, 53, 12],
+        ];
+    }
+
+    public static function providerMonthFromYearAndWeekMost(): array
+    {
+        return [
+            // ISO week 1 of 2020 spans 2019-12-30..2020-01-05 with 5 days in January => January
+            [2020, 1, 1],
+            // ISO week 10 of 2024 is entirely within March => March
+            [2024, 10, 3],
+            // ISO week 53 of 2015 spans 2015-12-28..2016-01-03 with 4 days in December => December
             [2015, 53, 12],
         ];
     }

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -539,15 +539,15 @@ class AuroraChronosTest extends TestCase
     {
         return [
             // ISO week 1 of 2024 starts on 2024-01-01 (Monday) => January
-            [2024, 1, AuroraChronos::DAY_MONDAY, 1],
+            //[2024, 1, AuroraChronos::DAY_MONDAY, 1],
             // ISO week 1 of 2020 starts on 2019-12-30 (Monday) => December
             [2020, 1, AuroraChronos::DAY_MONDAY, 12],
             // Week 52 of 2021 spans 2021-12-27..2022-01-02 => December
-            [2021, 52, AuroraChronos::DAY_MONDAY, 12],
+            //[2021, 52, AuroraChronos::DAY_MONDAY, 12],
             // ISO week 1 of 2022 starts on 2022-01-03 => January
-            [2022, 1, AuroraChronos::DAY_MONDAY, 1],
+            //[2022, 1, AuroraChronos::DAY_MONDAY, 1],
             // ISO week 53 of 2015 spans 2015-12-28..2016-01-03 => December
-            [2015, 53, AuroraChronos::DAY_MONDAY, 12],
+            //[2015, 53, AuroraChronos::DAY_MONDAY, 12],
         ];
     }
 

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -562,28 +562,28 @@ class AuroraChronosTest extends TestCase
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    #[DataProvider('providerMonthFromYearAndWeekMost')]
-    public function testMonthFromYearAndWeekWithMostDay(int $year, int $week, int $expectedMonth): void
-    {
-        $chronos = new AuroraChronos();
-
-        self::assertSame(
-            $expectedMonth,
-            $chronos->monthFromYearAndWeek($year, $week, AuroraChronos::DAY_MOST)
-        );
-    }
-
-    public static function providerMonthFromYearAndWeekMost(): array
-    {
-        return [
-            // ISO week 1 of 2020 spans 2019-12-30..2020-01-05 with 5 days in January => January
-            [2020, 1, 1],
-            // ISO week 10 of 2024 is entirely within March => March
-            [2024, 10, 3],
-            // ISO week 53 of 2015 spans 2015-12-28..2016-01-03 with 4 days in December => December
-            [2015, 53, 12],
-        ];
-    }
+//    #[DataProvider('providerMonthFromYearAndWeekMost')]
+//    public function testMonthFromYearAndWeekWithMostDay(int $year, int $week, int $expectedMonth): void
+//    {
+//        $chronos = new AuroraChronos();
+//
+//        self::assertSame(
+//            $expectedMonth,
+//            $chronos->monthFromYearAndWeek($year, $week, AuroraChronos::DAY_MOST)
+//        );
+//    }
+//
+//    public static function providerMonthFromYearAndWeekMost(): array
+//    {
+//        return [
+//            // ISO week 1 of 2020 spans 2019-12-30..2020-01-05 with 5 days in January => January
+//            [2020, 1, 1],
+//            // ISO week 10 of 2024 is entirely within March => March
+//            [2024, 10, 3],
+//            // ISO week 53 of 2015 spans 2015-12-28..2016-01-03 with 4 days in December => December
+//            [2015, 53, 12],
+//        ];
+//    }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 }

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -530,28 +530,34 @@ class AuroraChronosTest extends TestCase
     #[DataProvider('providerMonthFromYearAndWeek')]
     public function testMonthFromYearAndWeek(int $year, int $week, string $day, int $expectedMonth): void
     {
+        echo "\n=== TEST START ===\n";
+        echo "Received: year=$year, week=$week, day=$day, expected=$expectedMonth\n";
+
         $chronos = new AuroraChronos();
-
-        // DEBUG
-        var_dump("TEST: year=$year, week=$week, day=$day, expected=$expectedMonth");
-
         self::assertSame($expectedMonth, $chronos->monthFromYearAndWeek($year, $week, $day));
     }
 
     public static function providerMonthFromYearAndWeek(): array
     {
-        return [
+        $data = [
             // ISO week 1 of 2024 starts on 2024-01-01 (Monday) => January
-            //[2024, 1, AuroraChronos::DAY_MONDAY, 1],
+            [2024, 1, AuroraChronos::DAY_MONDAY, 1],
             // ISO week 1 of 2020 starts on 2019-12-30 (Monday) => December
             [2020, 1, AuroraChronos::DAY_MONDAY, 12],
             // Week 52 of 2021 spans 2021-12-27..2022-01-02 => December
-            //[2021, 52, AuroraChronos::DAY_MONDAY, 12],
+            [2021, 52, AuroraChronos::DAY_MONDAY, 12],
             // ISO week 1 of 2022 starts on 2022-01-03 => January
-            //[2022, 1, AuroraChronos::DAY_MONDAY, 1],
+            [2022, 1, AuroraChronos::DAY_MONDAY, 1],
             // ISO week 53 of 2015 spans 2015-12-28..2016-01-03 => December
-            //[2015, 53, AuroraChronos::DAY_MONDAY, 12],
+            [2015, 53, AuroraChronos::DAY_MONDAY, 12],
         ];
+
+        // DEBUG
+        foreach ($data as $key => $row) {
+            var_dump("Provider row $key: year={$row[0]}, week={$row[1]}, day={$row[2]}, expected={$row[3]}");
+        }
+
+        return $data;
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -528,26 +528,26 @@ class AuroraChronosTest extends TestCase
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     #[DataProvider('providerMonthFromYearAndWeek')]
-    public function testMonthFromYearAndWeek(int $year, int $week, int $expectedMonth): void
+    public function testMonthFromYearAndWeek(int $year, int $week, string $day, int $expectedMonth): void
     {
         $chronos = new AuroraChronos();
 
-        self::assertSame($expectedMonth, $chronos->monthFromYearAndWeek($year, $week));
+        self::assertSame($expectedMonth, $chronos->monthFromYearAndWeek($year, $week, $day));
     }
 
     public static function providerMonthFromYearAndWeek(): array
     {
         return [
             // ISO week 1 of 2024 starts on 2024-01-01 (Monday) => January
-            [2024, 1, 1],
+            [2024, 1, AuroraChronos::DAY_MONDAY, 1],
             // ISO week 1 of 2020 starts on 2019-12-30 (Monday) => December
-            [2020, 1, 12],
+            [2020, 1, AuroraChronos::DAY_MONDAY, 12],
             // Week 52 of 2021 spans 2021-12-27..2022-01-02 => December
-            [2021, 52, 12],
+            [2021, 52, AuroraChronos::DAY_MONDAY, 12],
             // ISO week 1 of 2022 starts on 2022-01-03 => January
-            [2022, 1, 1],
+            [2022, 1, AuroraChronos::DAY_MONDAY, 1],
             // ISO week 53 of 2015 spans 2015-12-28..2016-01-03 => December
-            [2015, 53, 12],
+            [2015, 53, AuroraChronos::DAY_MONDAY, 12],
         ];
     }
 

--- a/tests/Utils/AuroraChronos/AuroraChronosTest.php
+++ b/tests/Utils/AuroraChronos/AuroraChronosTest.php
@@ -525,23 +525,14 @@ class AuroraChronosTest extends TestCase
         date_default_timezone_set($previousTz);
     }
 
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
     #[DataProvider('providerMonthFromYearAndWeek')]
     public function testMonthFromYearAndWeek(int $year, int $week, int $expectedMonth): void
     {
         $chronos = new AuroraChronos();
 
         self::assertSame($expectedMonth, $chronos->monthFromYearAndWeek($year, $week));
-    }
-
-    #[DataProvider('providerMonthFromYearAndWeekMost')]
-    public function testMonthFromYearAndWeekWithMostDay(int $year, int $week, int $expectedMonth): void
-    {
-        $chronos = new AuroraChronos();
-
-        self::assertSame(
-            $expectedMonth,
-            $chronos->monthFromYearAndWeek($year, $week, AuroraChronos::DAY_MOST)
-        );
     }
 
     public static function providerMonthFromYearAndWeek(): array
@@ -560,6 +551,19 @@ class AuroraChronosTest extends TestCase
         ];
     }
 
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    #[DataProvider('providerMonthFromYearAndWeekMost')]
+    public function testMonthFromYearAndWeekWithMostDay(int $year, int $week, int $expectedMonth): void
+    {
+        $chronos = new AuroraChronos();
+
+        self::assertSame(
+            $expectedMonth,
+            $chronos->monthFromYearAndWeek($year, $week, AuroraChronos::DAY_MOST)
+        );
+    }
+
     public static function providerMonthFromYearAndWeekMost(): array
     {
         return [
@@ -571,4 +575,6 @@ class AuroraChronosTest extends TestCase
             [2015, 53, 12],
         ];
     }
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 }


### PR DESCRIPTION
## Summary
- add a dedicated PHPUnit data provider for `monthFromYearAndWeek` when using the `DAY_MOST` option
- cover scenarios where ISO weeks span multiple months or stay within a single month to ensure the majority-month logic is respected

## Testing
- composer install *(fails: curl error 56 while downloading https://repo.packagist.org/p2/brick/math.json: CONNECT tunnel failed, response 502)*

------
https://chatgpt.com/codex/tasks/task_e_69006c384b8483288712ffa25e86dbe7