### PR TITLE
Find and fix code bug

### DIFF
--- a/src/EventSubscriber/LocaleSubscriber.php
+++ b/src/EventSubscriber/LocaleSubscriber.php
@@ -64,7 +64,7 @@ class LocaleSubscriber implements EventSubscriberInterface
         $set = false;
         foreach ($locales as $localeLangCode) {
             // If first two chars of route are the same as locale lang code (eg: route `ro/lorem/ipsum` means the locale is `ro`)
-            if (!$set && strtolower($localeLangCode) == strtolower(substr($routeName, -2))) {
+            if (!$set && strtolower($localeLangCode) == strtolower(substr($routeName, 0, 2))) {
                 $this->setLocale($localeLangCode, $request);
                 $set = true;
             }


### PR DESCRIPTION
…st 2

The setLocaleByRouteName method was incorrectly using substr($routeName, -2) which extracts the last 2 characters of the route name. According to the comment and intended logic, it should check the first 2 characters to match the locale lang code (e.g., route 'ro/lorem/ipsum' should match locale 'ro').

Changed substr($routeName, -2) to substr($routeName, 0, 2) on line 67.