### PR TITLE
Update PHPUnit workflow badge download

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -238,6 +238,8 @@ jobs:
                 if: steps.check_branch.outputs.should_commit == 'true'
                 working-directory: ${{ env.BUILD_DIR }}
                 run: |
+                    mkdir -p ../.github/badges
+
                     /usr/bin/php bin/console aurora:php-unit \
                     --action=generatePHPUnitPassingBadge \
                     --junitXMLFilePath=${{ env.BUILD_DIR }}/.github/.test-results/junit.xml \
@@ -249,6 +251,10 @@ jobs:
                     --outputCoverageSVGFilePath=../.github/badges/coverage.svg \
                     --outputStatementsSVGFilePath=../.github/badges/statements.svg
 
+                    curl -L \
+                    "https://github.com/SindlaXYZ/Aurora/actions/workflows/phpunit.yml/badge.svg" \
+                    -o ../.github/badges/phpunit-tests.svg
+
             -   name: "Commit PHPUnit badges"
                 if: steps.check_branch.outputs.should_commit == 'true'
                 run: |
@@ -258,7 +264,7 @@ jobs:
                     git config --global pull.rebase true
                     git config --global rebase.autoStash true
                     git pull origin "HEAD:${BRANCH}"
-                    git add .github/badges/coverage.svg .github/badges/phpunit.svg .github/badges/statements.svg
+                    git add .github/badges/coverage.svg .github/badges/phpunit.svg .github/badges/phpunit-tests.svg .github/badges/statements.svg
                     git commit -m "Update PHPUnit badges" || echo "No changes to commit"
                     git push origin "HEAD:${BRANCH}"
 


### PR DESCRIPTION
## Summary
- ensure PHPUnit badge generation creates the badges directory
- download the workflow status badge to .github/badges/phpunit-tests.svg after tests
- include the new badge in the automatic commit and push step

## Testing
- not run (workflow changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ebf542c48832885cead7834398ce6)