### PR TITLE
Fix PWA version append configuration typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ parameters:
     #aurora.pwa.version_append:        "!php/eval `date('Y-m-d H')`"
     aurora.pwa.enabled: '%env(bool:AURORA_PWA_ENABLED)%'
     aurora.pwa.debug: '%env(bool:AURORA_PWA_DEBUG)%'
-    aurora.pwa.version_append: "!php/eval `App\Utils::pwaVersioAppend()`"
+    aurora.pwa.version_append: "!php/eval `App\Utils::pwaVersionAppend()`"
     aurora.pwa.automatically_prompt: false
     aurora.pwa.app_name: ''
     aurora.pwa.app_short_name: ''

--- a/src/Resources/schema/packages/aurora.yaml
+++ b/src/Resources/schema/packages/aurora.yaml
@@ -14,7 +14,7 @@ parameters:
     aurora.minify.output.ignore.content.type: ['text/plain', 'text/csv', 'application/octet-stream', 'image/jpeg', 'image/png', 'image/gif', 'application/pdf', 'application/xml', 'application/zip']
     # https://developers.google.com/web/fundamentals/web-app-manifest
     #aurora.pwa.version_append:        "!php/eval `date('Y-m-d H')`"
-    aurora.pwa.version_append: "!php/eval `App\Utils::pwaVersioAppend()`"
+    aurora.pwa.version_append: "!php/eval `App\Utils::pwaVersionAppend()`"
     aurora.pwa.automatically_prompt: false
     aurora.pwa.app_name: ''
     aurora.pwa.app_short_name: ''


### PR DESCRIPTION
## Summary
- correct the PWA version_append example to reference `pwaVersionAppend`
- align schema configuration snippet with the corrected method name

## Testing
- not run (documentation and configuration examples only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec133ed188328b8d025e0ea7bfc05)